### PR TITLE
SPOI-5728: Update Malhar with changes made by Ingestion app to Malhar operators

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/io/block/AbstractFSBlockReader.java
+++ b/library/src/main/java/com/datatorrent/lib/io/block/AbstractFSBlockReader.java
@@ -56,7 +56,9 @@ public abstract class AbstractFSBlockReader<R> extends AbstractBlockReader<R, Bl
   {
     super.teardown();
     try {
-      fs.close();
+      if (fs != null) {
+        fs.close();
+      }
     }
     catch (IOException e) {
       throw new RuntimeException(e);

--- a/library/src/main/java/com/datatorrent/lib/io/block/FileReaderUtils.java
+++ b/library/src/main/java/com/datatorrent/lib/io/block/FileReaderUtils.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datatorrent.lib.io.block;
+
+import java.net.URI;
+
+import com.google.common.base.Splitter;
+
+public class FileReaderUtils
+{
+
+  /**
+   * Converts Scheme part of the URI to lower case. Multiple URI can be comma separated. If no scheme is there, no
+   * change is made.
+   *
+   * @param
+   * @return String with scheme part as lower case
+   */
+  public static String convertSchemeToLowerCase(String uri)
+  {
+    if (uri == null) {
+      return null;
+    }
+    StringBuilder inputMod = new StringBuilder();
+    for (String f : Splitter.on(",").omitEmptyStrings().split(uri)) {
+      String scheme = URI.create(f).getScheme();
+      if (scheme != null) {
+        inputMod.append(f.replaceFirst(scheme, scheme.toLowerCase()));
+      } else {
+        inputMod.append(f);
+      }
+      inputMod.append(",");
+    }
+    inputMod.setLength(inputMod.length() - 1);
+    return inputMod.toString();
+  }
+}

--- a/library/src/test/java/com/datatorrent/lib/io/block/FileReaderUtilsTest.java
+++ b/library/src/test/java/com/datatorrent/lib/io/block/FileReaderUtilsTest.java
@@ -1,0 +1,39 @@
+package com.datatorrent.lib.io.block;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FileReaderUtilsTest
+{
+
+  @Test
+  public void testUpperCaseSchemeToLowerCase() throws URISyntaxException
+  {
+    String scheme = "HDFS";
+    String host = "mynode.cluster.com:8020";
+    String path = "/user/MyUser/input";
+    URI uri = new URI(scheme + "://" + host + path);
+    String processedUriStr = FileReaderUtils.convertSchemeToLowerCase(uri.toString());
+    URI processedUri = new URI(processedUriStr);
+
+    Assert.assertEquals(scheme.toLowerCase(), processedUri.getScheme());
+    Assert.assertEquals(path, processedUri.getPath());
+  }
+
+  @Test
+  public void testMixedCaseSchemetoLawerCase() throws URISyntaxException
+  {
+    String scheme = "Ftp";
+    String host = "mynode.cluster.com:8020";
+    String path = "/user/MyUser/INPUT";
+    URI uri = new URI(scheme + "://" + host + path);
+    String processedUriStr = FileReaderUtils.convertSchemeToLowerCase(uri.toString());
+    URI processedUri = new URI(processedUriStr);
+
+    Assert.assertEquals(scheme.toLowerCase(), processedUri.getScheme());
+    Assert.assertEquals(path, processedUri.getPath());
+  }
+}


### PR DESCRIPTION
FileReaderUtils is going to be used by FileSplitter (The pull request yet to be raised).
The use case is:
We want to handle upper/lower case scheme input for FileSplitter input.
