### PR TITLE
- MLHR-1876 #resolve Cleanly terminated window bounded service thread…

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/io/WebSocketInputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/io/WebSocketInputOperator.java
@@ -137,6 +137,15 @@ public class WebSocketInputOperator<T> extends SimpleSinglePortInputOperator<T> 
     catch (Exception ex) {
       LOG.error("Error joining monitor", ex);
     }
+
+    if (connection != null) {
+      connection.close();
+    }
+
+    if (client != null) {
+      client.close();
+    }
+
     super.teardown();
   }
 

--- a/library/src/test/java/com/datatorrent/lib/appdata/query/WindowBoundedServiceTest.java
+++ b/library/src/test/java/com/datatorrent/lib/appdata/query/WindowBoundedServiceTest.java
@@ -64,33 +64,6 @@ public class WindowBoundedServiceTest
     Assert.assertTrue(counterRunnable.getCounter() > 0);
   }
 
-  @Test
-  public void exceptionTest() throws Exception
-  {
-    WindowBoundedService wbs = new WindowBoundedService(1,
-                                                        new ExceptionRunnable());
-
-    wbs.setup(null);
-    wbs.beginWindow(0);
-
-    boolean caughtException = false;
-
-    try {
-      Thread.sleep(500);
-    } catch (InterruptedException e) {
-      caughtException = true;
-    }
-
-    try {
-      wbs.endWindow();
-    } catch(Exception e) {
-      caughtException = true;
-    }
-
-    wbs.teardown();
-    Assert.assertEquals(true, caughtException);
-  }
-
   public static class CounterRunnable implements Runnable
   {
     private int counter = 0;


### PR DESCRIPTION
… and removed unnecessary interrupt of main operator thread.
- Fixed emitting schemas on output port in a different thread.
- Closed connections in WebSocketInput Operator on teardown
- Removed obsolete unit test
