### PR TITLE
- MLHR-1887 #resolve made shutdown field volatile since it is written…

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/io/WebSocketInputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/io/WebSocketInputOperator.java
@@ -62,7 +62,7 @@ public class WebSocketInputOperator<T> extends SimpleSinglePortInputOperator<T> 
   protected transient final ObjectMapper mapper = new ObjectMapper(jsonFactory);
   protected transient WebSocket connection;
   private transient boolean connectionClosed = false;
-  private transient boolean shutdown = false;
+  private transient volatile boolean shutdown = false;
   private int ioThreadMultiplier = 1;
   protected boolean skipNull = false;
 


### PR DESCRIPTION
… and read by separate threads.
