### PR TITLE
MLHR-1914: Add base operators to ease operator API

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputListOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputListOutput.java
@@ -1,13 +1,13 @@
 package com.datatorrent.lib.complex;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.datatorrent.api.DefaultInputPort;
 import com.datatorrent.api.DefaultOutputPort;
 import com.datatorrent.api.annotation.Name;
 import com.datatorrent.api.annotation.Stateless;
 import com.datatorrent.common.util.BaseOperator;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A base implementation of an operator that abstracts away the input and output port.
@@ -43,23 +43,26 @@ import java.util.List;
  */
 @Stateless
 @Name("all-way-multiple-input-list-output")
-public abstract class AllWayMultiInputListOutput<I, O> extends BaseOperator {
+public abstract class AllWayMultiInputListOutput<I, O> extends BaseOperator
+{
   protected static final int DEFAULT_NUM_INPUTS = 2;
   protected static final int DEFAULT_NUM_OUTPUTS = 2;
 
   protected transient List<DefaultInputPort<I>> inputs = null;
   protected transient List<DefaultOutputPort<O>> outputs = null;
 
-  public AllWayMultiInputListOutput() throws InstantiationException {
+  public AllWayMultiInputListOutput() throws InstantiationException
+  {
     this(DEFAULT_NUM_INPUTS, DEFAULT_NUM_OUTPUTS);
   }
 
-  public AllWayMultiInputListOutput(int numInputs, int numOutputs) throws InstantiationException {
+  public AllWayMultiInputListOutput(int numInputs, int numOutputs) throws InstantiationException
+  {
     if (numInputs < 1 || numInputs > 65535) {
-      throw new InstantiationException("Cannot instantiate with "+numInputs+
+      throw new InstantiationException("Cannot instantiate with " + numInputs +
           "; must be 1 < numInputs < 65535");
     } else if (numOutputs < 1 || numOutputs > 65535) {
-      throw new InstantiationException("Cannot instantiate with "+numOutputs+
+      throw new InstantiationException("Cannot instantiate with " + numOutputs +
           "; must be 1 < numOutputs < 65535");
     } else {
       inputs = new ArrayList<DefaultInputPort<I>>(numInputs);
@@ -72,7 +75,8 @@ public abstract class AllWayMultiInputListOutput<I, O> extends BaseOperator {
       for (int i = 0; i < numInputs; ++i) {
         inputs.add(new DefaultInputPort<I>() {
           @Override
-          public void process(I inputTuple) {
+          public void process(I inputTuple)
+          {
             List<O> results = AllWayMultiInputListOutput.this.process(inputTuple);
 
             for (int i = 0; i < outputs.size(); ++i) {

--- a/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputListOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputListOutput.java
@@ -1,0 +1,91 @@
+package com.datatorrent.lib.complex;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.annotation.Name;
+import com.datatorrent.api.annotation.Stateless;
+import com.datatorrent.common.util.BaseOperator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A base implementation of an operator that abstracts away the input and output port.
+ *
+ * Subclasses should provide the implementation to process a tuple of type I and return a list of
+ * tuples of type O such that each element in the list will be output to its corresponding output
+ * port based on their equal indices (i.e. output[0] receives tuple[0], output[1] receives tuple[1],
+ * etc.). This operator is equivalent to {@link com.datatorrent.lib.complex.SingleInputListOutput
+ * SingleInputOutputList} except allowing multiple input ports.
+ *
+ * In the event that the tuple list is smaller than the number of output ports the values are
+ * deterministically emitted out to each port until the list is exhausted starting with the first
+ * element. In the case where the tuple list is larger than the number of output ports only the
+ * first tuples that correctly match their indices with the output ports are emitted and all else
+ * are wasted.
+ *
+ * <p>
+ * <b>Input Port(s) :</b><br>
+ * <b> input[] :</b> input port list with a default of two ports. <br>
+ * <br>
+ * <b>Output Port(s) :</b><br>
+ * <b> output[] :</b> output port list with a default of two ports. <br>
+ * <br>
+ * <b>Stateful : No</b>, all state is handled through the implementing class. <br>
+ * <b>Partitions : Yes</b>, no dependency among input tuples. <br>
+ * <br>
+ * @displayName All Way Multiple Input With List Output
+ * @category Complex Operators
+ * @tags complex, multiple input, list output
+ * @param <I> type being received from the input port
+ * @param <O> type being sent from the output port
+ * @since 3.3.0
+ */
+@Stateless
+@Name("all-way-multiple-input-list-output")
+public abstract class AllWayMultiInputListOutput<I, O> extends BaseOperator {
+  protected static final int DEFAULT_NUM_INPUTS = 2;
+  protected static final int DEFAULT_NUM_OUTPUTS = 2;
+
+  protected transient List<DefaultInputPort<I>> inputs = null;
+  protected transient List<DefaultOutputPort<O>> outputs = null;
+
+  public AllWayMultiInputListOutput() throws InstantiationException {
+    this(DEFAULT_NUM_INPUTS, DEFAULT_NUM_OUTPUTS);
+  }
+
+  public AllWayMultiInputListOutput(int numInputs, int numOutputs) throws InstantiationException {
+    if (numInputs < 1 || numInputs > 65535) {
+      throw new InstantiationException("Cannot instantiate with "+numInputs+
+          "; must be 1 < numInputs < 65535");
+    } else if (numOutputs < 1 || numOutputs > 65535) {
+      throw new InstantiationException("Cannot instantiate with "+numOutputs+
+          "; must be 1 < numOutputs < 65535");
+    } else {
+      inputs = new ArrayList<DefaultInputPort<I>>(numInputs);
+      outputs = new ArrayList<DefaultOutputPort<O>>(numOutputs);
+
+      for (int i = 0; i < numOutputs; ++i) {
+        outputs.add(new DefaultOutputPort<O>());
+      }
+
+      for (int i = 0; i < numInputs; ++i) {
+        inputs.add(new DefaultInputPort<I>() {
+          @Override
+          public void process(I inputTuple) {
+            List<O> results = AllWayMultiInputListOutput.this.process(inputTuple);
+
+            for (int i = 0; i < outputs.size(); ++i) {
+              O result;
+              if ((result = results.get(i)) != null) {
+                outputs.get(i).emit(result);
+              }
+            }
+          }
+        });
+      }
+    }
+  }
+
+  public abstract List<O> process(I inputTuple);
+}

--- a/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputListOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputListOutput.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.complex;
 
 import java.util.ArrayList;

--- a/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputOutput.java
@@ -1,13 +1,13 @@
 package com.datatorrent.lib.complex;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.datatorrent.api.DefaultInputPort;
 import com.datatorrent.api.DefaultOutputPort;
 import com.datatorrent.api.annotation.Name;
 import com.datatorrent.api.annotation.Stateless;
 import com.datatorrent.common.util.BaseOperator;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A base implementation of an operator that abstracts away the input and output port.
@@ -34,23 +34,26 @@ import java.util.List;
  */
 @Stateless
 @Name("all-way-multiple-input-output")
-public abstract class AllWayMultiInputOutput<I, O> extends BaseOperator {
+public abstract class AllWayMultiInputOutput<I, O> extends BaseOperator
+{
   protected static final int DEFAULT_NUM_INPUTS = 2;
   protected static final int DEFAULT_NUM_OUTPUTS = 2;
 
   protected transient List<DefaultInputPort<I>> inputs = null;
   protected transient List<DefaultOutputPort<O>> outputs = null;
 
-  public AllWayMultiInputOutput() throws InstantiationException {
+  public AllWayMultiInputOutput() throws InstantiationException
+  {
     this(DEFAULT_NUM_INPUTS, DEFAULT_NUM_OUTPUTS);
   }
 
-  public AllWayMultiInputOutput(int numInputs, int numOutputs) throws InstantiationException {
+  public AllWayMultiInputOutput(int numInputs, int numOutputs) throws InstantiationException
+  {
     if (numInputs < 1 || numInputs > 65535) {
-      throw new InstantiationException("Cannot instantiate with "+numInputs+
+      throw new InstantiationException("Cannot instantiate with " + numInputs +
           "; must be 1 < numInputs < 65535");
     } else if (numOutputs < 1 || numOutputs > 65535) {
-      throw new InstantiationException("Cannot instantiate with "+numOutputs+
+      throw new InstantiationException("Cannot instantiate with " + numOutputs +
           "; must be 1 < numOutputs < 65535");
     } else {
       inputs = new ArrayList<DefaultInputPort<I>>(numInputs);
@@ -63,7 +66,8 @@ public abstract class AllWayMultiInputOutput<I, O> extends BaseOperator {
       for (int i = 0; i < numInputs; ++i) {
         inputs.add(new DefaultInputPort<I>() {
           @Override
-          public void process(I inputTuple) {
+          public void process(I inputTuple)
+          {
             O result;
 
             if ((result = AllWayMultiInputOutput.this.process(inputTuple)) != null) {

--- a/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputOutput.java
@@ -1,0 +1,81 @@
+package com.datatorrent.lib.complex;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.annotation.Name;
+import com.datatorrent.api.annotation.Stateless;
+import com.datatorrent.common.util.BaseOperator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A base implementation of an operator that abstracts away the input and output port.
+ *
+ * Subclasses should provide the implementation to process a tuple of type I and return a tuple of
+ * type O such that the return value from each input port will emit from every output port.
+ *
+ * <p>
+ * <b>Input Port(s) :</b><br>
+ * <b> input[] :</b> input port list with a default of two ports. <br>
+ * <br>
+ * <b>Output Port(s) :</b><br>
+ * <b> output[] :</b> output port list with a default of two ports. <br>
+ * <br>
+ * <b>Stateful : No</b>, all state is handled through the implementing class. <br>
+ * <b>Partitions : Yes</b>, no dependency among input tuples. <br>
+ * <br>
+ * @displayName All Way Multiple Input & Output
+ * @category Complex Operators
+ * @tags complex, multiple input, multiple output
+ * @param <I> type being received from the input port
+ * @param <O> type being sent from the output port
+ * @since 3.3.0
+ */
+@Stateless
+@Name("all-way-multiple-input-output")
+public abstract class AllWayMultiInputOutput<I, O> extends BaseOperator {
+  protected static final int DEFAULT_NUM_INPUTS = 2;
+  protected static final int DEFAULT_NUM_OUTPUTS = 2;
+
+  protected transient List<DefaultInputPort<I>> inputs = null;
+  protected transient List<DefaultOutputPort<O>> outputs = null;
+
+  public AllWayMultiInputOutput() throws InstantiationException {
+    this(DEFAULT_NUM_INPUTS, DEFAULT_NUM_OUTPUTS);
+  }
+
+  public AllWayMultiInputOutput(int numInputs, int numOutputs) throws InstantiationException {
+    if (numInputs < 1 || numInputs > 65535) {
+      throw new InstantiationException("Cannot instantiate with "+numInputs+
+          "; must be 1 < numInputs < 65535");
+    } else if (numOutputs < 1 || numOutputs > 65535) {
+      throw new InstantiationException("Cannot instantiate with "+numOutputs+
+          "; must be 1 < numOutputs < 65535");
+    } else {
+      inputs = new ArrayList<DefaultInputPort<I>>(numInputs);
+      outputs = new ArrayList<DefaultOutputPort<O>>(numOutputs);
+
+      for (int i = 0; i < numOutputs; ++i) {
+        outputs.add(new DefaultOutputPort<O>());
+      }
+
+      for (int i = 0; i < numInputs; ++i) {
+        inputs.add(new DefaultInputPort<I>() {
+          @Override
+          public void process(I inputTuple) {
+            O result;
+
+            if ((result = AllWayMultiInputOutput.this.process(inputTuple)) != null) {
+              for (DefaultOutputPort<O> output : outputs) {
+                output.emit(result);
+              }
+            }
+          }
+        });
+      }
+    }
+  }
+
+  public abstract O process(I inputTuple);
+}

--- a/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/AllWayMultiInputOutput.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.complex;
 
 import java.util.ArrayList;

--- a/library/src/main/java/com/datatorrent/lib/complex/DirectMultiInputOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/DirectMultiInputOutput.java
@@ -1,13 +1,13 @@
 package com.datatorrent.lib.complex;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.datatorrent.api.DefaultInputPort;
 import com.datatorrent.api.DefaultOutputPort;
 import com.datatorrent.api.annotation.Name;
 import com.datatorrent.api.annotation.Stateless;
 import com.datatorrent.common.util.BaseOperator;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A base implementation of an operator that abstracts away the input and output ports.
@@ -36,19 +36,22 @@ import java.util.List;
  */
 @Stateless
 @Name("direct-multi-input-output")
-public abstract class DirectMultiInputOutput<I, O> extends BaseOperator {
+public abstract class DirectMultiInputOutput<I, O> extends BaseOperator
+{
   protected static final int DEFAULT_NUM_INPUTS_OUTPUTS = 2;
 
   protected transient List<DefaultInputPort<I>> inputs = null;
   protected transient List<DefaultOutputPort<O>> outputs = null;
 
-  public DirectMultiInputOutput() throws InstantiationException {
+  public DirectMultiInputOutput() throws InstantiationException
+  {
     this(DEFAULT_NUM_INPUTS_OUTPUTS);
   }
 
-  public DirectMultiInputOutput(int numInputsOutputs) throws InstantiationException {
+  public DirectMultiInputOutput(int numInputsOutputs) throws InstantiationException
+  {
     if (numInputsOutputs < 1 || numInputsOutputs > 65535) {
-      throw new InstantiationException("Cannot instantiate with "+numInputsOutputs+
+      throw new InstantiationException("Cannot instantiate with " + numInputsOutputs +
           "; must be 1 < numInputsOutputs < 65535");
     } else {
       inputs = new ArrayList<DefaultInputPort<I>>(numInputsOutputs);
@@ -60,7 +63,8 @@ public abstract class DirectMultiInputOutput<I, O> extends BaseOperator {
 
         inputs.add(new DefaultInputPort<I>() {
           @Override
-          public void process(I inputTuple) {
+          public void process(I inputTuple)
+          {
             O result;
             if ((result = DirectMultiInputOutput.this.process(inputTuple)) != null) {
               output.emit(result);

--- a/library/src/main/java/com/datatorrent/lib/complex/DirectMultiInputOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/DirectMultiInputOutput.java
@@ -1,0 +1,75 @@
+package com.datatorrent.lib.complex;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.annotation.Name;
+import com.datatorrent.api.annotation.Stateless;
+import com.datatorrent.common.util.BaseOperator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A base implementation of an operator that abstracts away the input and output ports.
+ *
+ * Subclasses should provide the implementation to process a tuple of type I and return a tuple of
+ * type O such that for each input port the tuple is directly mapped to its corresponding output
+ * port based on their equivalent indices. Input ports and output ports are always guaranteed to be
+ * balanced (equal).
+ *
+ * <p>
+ * <b>Input Port(s) :</b><br>
+ * <b> input[] :</b> input port list with a default of two ports. <br>
+ * <br>
+ * <b>Output Port(s) :</b><br>
+ * <b> output[] :</b> output port list with a default of two ports. <br>
+ * <br>
+ * <b>Stateful : No</b>, all state is handled through the implementing class. <br>
+ * <b>Partitions : Yes</b>, no dependency among input tuples. <br>
+ * <br>
+ * @displayName Direct Multiple Input & Output
+ * @category Complex Operators
+ * @tags complex, direct, multiple input, multiple output
+ * @param <I> type being received from the input port
+ * @param <O> type being sent from the output port
+ * @since 3.3.0
+ */
+@Stateless
+@Name("direct-multi-input-output")
+public abstract class DirectMultiInputOutput<I, O> extends BaseOperator {
+  protected static final int DEFAULT_NUM_INPUTS_OUTPUTS = 2;
+
+  protected transient List<DefaultInputPort<I>> inputs = null;
+  protected transient List<DefaultOutputPort<O>> outputs = null;
+
+  public DirectMultiInputOutput() throws InstantiationException {
+    this(DEFAULT_NUM_INPUTS_OUTPUTS);
+  }
+
+  public DirectMultiInputOutput(int numInputsOutputs) throws InstantiationException {
+    if (numInputsOutputs < 1 || numInputsOutputs > 65535) {
+      throw new InstantiationException("Cannot instantiate with "+numInputsOutputs+
+          "; must be 1 < numInputsOutputs < 65535");
+    } else {
+      inputs = new ArrayList<DefaultInputPort<I>>(numInputsOutputs);
+      outputs = new ArrayList<DefaultOutputPort<O>>(numInputsOutputs);
+
+      for (int i = 0; i < numInputsOutputs; ++i) {
+        final DefaultOutputPort<O> output = new DefaultOutputPort<O>();
+        outputs.add(output);
+
+        inputs.add(new DefaultInputPort<I>() {
+          @Override
+          public void process(I inputTuple) {
+            O result;
+            if ((result = DirectMultiInputOutput.this.process(inputTuple)) != null) {
+              output.emit(result);
+            }
+          }
+        });
+      }
+    }
+  }
+
+  public abstract O process(I inputTuple);
+}

--- a/library/src/main/java/com/datatorrent/lib/complex/DirectMultiInputOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/DirectMultiInputOutput.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.complex;
 
 import java.util.ArrayList;

--- a/library/src/main/java/com/datatorrent/lib/complex/SingleInputListOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/SingleInputListOutput.java
@@ -1,0 +1,86 @@
+package com.datatorrent.lib.complex;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.annotation.Name;
+import com.datatorrent.api.annotation.Stateless;
+import com.datatorrent.common.util.BaseOperator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A base implementation of an operator that abstracts away the input and output ports.
+ *
+ * Subclasses should provide the implementation to process a tuple of type I and return a list of
+ * tuples of type O such that each element in the list will be output to its corresponding output
+ * port based on their equal indices (i.e. output[0] receives tuple[0], output[1] receives tuple[1],
+ * etc.).
+ *
+ * In the event that the tuple list is smaller than the number of output ports the values are
+ * deterministically emitted out to each port until the list is exhausted starting with the first
+ * element. In the case where the tuple list is larger than the number of output ports only the
+ * first tuples that correctly match their indices with the output ports are emitted and all else
+ * are wasted.
+ *
+ * <p>
+ * <b>Input Port :</b><br>
+ * <b> input :</b> default input port. <br>
+ * <br>
+ * <b>Output Port(s) :</b><br>
+ * <b> output[] :</b> output port list with a default of two ports. <br>
+ * <br>
+ * <b>Stateful : No</b>, all state is handled through the implementing class. <br>
+ * <b>Partitions : Yes</b>, no dependency among input tuples. <br>
+ * <br>
+ * @displayName Single Input With List Output
+ * @category Complex Operators
+ * @tags complex, single input, list output
+ * @param <I> type being received from the input port
+ * @param <O> type being sent from the output port
+ * @since 3.3.0
+ */
+@Stateless
+@Name("single-input-list-output")
+public abstract class SingleInputListOutput<I, O> extends BaseOperator {
+  protected static final int DEFAULT_NUM_OUTPUTS = 2;
+
+  protected transient List<DefaultOutputPort<O>> outputs = null;
+
+  protected transient final DefaultInputPort<I> input = new DefaultInputPort<I>() {
+    @Override
+    public void process(I inputTuple) {
+      List<O> resultList = SingleInputListOutput.this.process(inputTuple);
+      resultList = resultList != null ? resultList : new ArrayList<O>();
+
+      int minOutputSize = resultList.size() < outputs.size() ?
+          resultList.size() : outputs.size();
+
+      for (int i = 0; i < minOutputSize; ++i) {
+        O result;
+        if ((result = resultList.get(i)) != null) {
+          outputs.get(i).emit(result);
+        }
+      }
+    }
+  };
+
+  public SingleInputListOutput(int numOutputs) throws InstantiationException {
+    if (numOutputs < 1 || numOutputs > 65535) {
+      throw new InstantiationException("Cannot instantiate with "+numOutputs+
+          "; must be 1 < numOutputs < 65535");
+    } else {
+      this.outputs = new ArrayList<DefaultOutputPort<O>>(numOutputs);
+
+      for (int i = 0; i < numOutputs; ++i) {
+        this.outputs.add(new DefaultOutputPort<O>());
+      }
+    }
+  }
+
+  public SingleInputListOutput() throws InstantiationException {
+    this(DEFAULT_NUM_OUTPUTS);
+  }
+
+  public abstract List<O> process(I inputTuple);
+}

--- a/library/src/main/java/com/datatorrent/lib/complex/SingleInputListOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/SingleInputListOutput.java
@@ -1,13 +1,13 @@
 package com.datatorrent.lib.complex;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.datatorrent.api.DefaultInputPort;
 import com.datatorrent.api.DefaultOutputPort;
 import com.datatorrent.api.annotation.Name;
 import com.datatorrent.api.annotation.Stateless;
 import com.datatorrent.common.util.BaseOperator;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A base implementation of an operator that abstracts away the input and output ports.
@@ -42,14 +42,16 @@ import java.util.List;
  */
 @Stateless
 @Name("single-input-list-output")
-public abstract class SingleInputListOutput<I, O> extends BaseOperator {
+public abstract class SingleInputListOutput<I, O> extends BaseOperator
+{
   protected static final int DEFAULT_NUM_OUTPUTS = 2;
 
   protected transient List<DefaultOutputPort<O>> outputs = null;
 
-  protected transient final DefaultInputPort<I> input = new DefaultInputPort<I>() {
+  protected final transient DefaultInputPort<I> input = new DefaultInputPort<I>() {
     @Override
-    public void process(I inputTuple) {
+    public void process(I inputTuple)
+    {
       List<O> resultList = SingleInputListOutput.this.process(inputTuple);
       resultList = resultList != null ? resultList : new ArrayList<O>();
 
@@ -65,9 +67,10 @@ public abstract class SingleInputListOutput<I, O> extends BaseOperator {
     }
   };
 
-  public SingleInputListOutput(int numOutputs) throws InstantiationException {
+  public SingleInputListOutput(int numOutputs) throws InstantiationException
+  {
     if (numOutputs < 1 || numOutputs > 65535) {
-      throw new InstantiationException("Cannot instantiate with "+numOutputs+
+      throw new InstantiationException("Cannot instantiate with " + numOutputs +
           "; must be 1 < numOutputs < 65535");
     } else {
       this.outputs = new ArrayList<DefaultOutputPort<O>>(numOutputs);
@@ -78,7 +81,8 @@ public abstract class SingleInputListOutput<I, O> extends BaseOperator {
     }
   }
 
-  public SingleInputListOutput() throws InstantiationException {
+  public SingleInputListOutput() throws InstantiationException
+  {
     this(DEFAULT_NUM_OUTPUTS);
   }
 

--- a/library/src/main/java/com/datatorrent/lib/complex/SingleInputListOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/complex/SingleInputListOutput.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.complex;
 
 import java.util.ArrayList;

--- a/library/src/main/java/com/datatorrent/lib/simple/MultiInputSingleOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/simple/MultiInputSingleOutput.java
@@ -1,0 +1,70 @@
+package com.datatorrent.lib.simple;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.annotation.Name;
+import com.datatorrent.api.annotation.Stateless;
+import com.datatorrent.common.util.BaseOperator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A base implementation of an operator that abstracts away the input ports and output port.
+ *
+ * Subclasses should provide the implementation to process a tuple of type I and return a tuple of
+ * type O such that each value from the input ports maps to the single output port.
+ *
+ * <p>
+ * <b>Input Port(s) :</b><br>
+ * <b> input[] :</b> input port list that defaults to two ports. <br>
+ * <br>
+ * <b>Output Port :</b><br>
+ * <b> output :</b> default output port. <br>
+ * <br>
+ * <b>Stateful : No</b>, all state is handled through the implementing class. <br>
+ * <b>Partitions : Yes</b>, no dependency among input tuples. <br>
+ * <br>
+ * @displayName Multiple Input With Single Output
+ * @category Simple Operators
+ * @tags simple, multiple input, single output
+ * @param <I> type being received from the input port
+ * @param <O> type being sent from the output port
+ * @since 3.3.0
+ */
+@Stateless
+@Name("multi-input-single-output")
+public abstract class MultiInputSingleOutput<I, O> extends BaseOperator {
+  protected static final int DEFAULT_NUM_INPUTS = 2;
+
+  protected transient final DefaultOutputPort<O> output = new DefaultOutputPort<O>();
+
+  protected transient List<DefaultInputPort<I>> inputs = null;
+
+  public MultiInputSingleOutput(int numInputs) throws InstantiationException {
+    if (numInputs < 1 || numInputs > 65535) {
+      throw new InstantiationException("Cannot instantiate with "+numInputs+
+          "; must be 1 < numInputs < 65535");
+    } else {
+      this.inputs = new ArrayList<DefaultInputPort<I>>(numInputs);
+
+      for (int i = 0; i < numInputs; ++i) {
+        inputs.add(new DefaultInputPort<I>() {
+          @Override
+          public void process(I i) {
+            O result;
+            if ((result = MultiInputSingleOutput.this.process(i)) != null) {
+              output.emit(result);
+            }
+          }
+        });
+      }
+    }
+  }
+
+  public MultiInputSingleOutput() throws InstantiationException {
+    this(DEFAULT_NUM_INPUTS);
+  }
+
+  public abstract O process(I inputTuple);
+}

--- a/library/src/main/java/com/datatorrent/lib/simple/MultiInputSingleOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/simple/MultiInputSingleOutput.java
@@ -1,13 +1,13 @@
 package com.datatorrent.lib.simple;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.datatorrent.api.DefaultInputPort;
 import com.datatorrent.api.DefaultOutputPort;
 import com.datatorrent.api.annotation.Name;
 import com.datatorrent.api.annotation.Stateless;
 import com.datatorrent.common.util.BaseOperator;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A base implementation of an operator that abstracts away the input ports and output port.
@@ -34,16 +34,18 @@ import java.util.List;
  */
 @Stateless
 @Name("multi-input-single-output")
-public abstract class MultiInputSingleOutput<I, O> extends BaseOperator {
+public abstract class MultiInputSingleOutput<I, O> extends BaseOperator
+{
   protected static final int DEFAULT_NUM_INPUTS = 2;
 
-  protected transient final DefaultOutputPort<O> output = new DefaultOutputPort<O>();
+  protected final transient DefaultOutputPort<O> output = new DefaultOutputPort<O>();
 
   protected transient List<DefaultInputPort<I>> inputs = null;
 
-  public MultiInputSingleOutput(int numInputs) throws InstantiationException {
+  public MultiInputSingleOutput(int numInputs) throws InstantiationException
+  {
     if (numInputs < 1 || numInputs > 65535) {
-      throw new InstantiationException("Cannot instantiate with "+numInputs+
+      throw new InstantiationException("Cannot instantiate with " + numInputs +
           "; must be 1 < numInputs < 65535");
     } else {
       this.inputs = new ArrayList<DefaultInputPort<I>>(numInputs);
@@ -51,7 +53,8 @@ public abstract class MultiInputSingleOutput<I, O> extends BaseOperator {
       for (int i = 0; i < numInputs; ++i) {
         inputs.add(new DefaultInputPort<I>() {
           @Override
-          public void process(I i) {
+          public void process(I i)
+          {
             O result;
             if ((result = MultiInputSingleOutput.this.process(i)) != null) {
               output.emit(result);
@@ -62,7 +65,8 @@ public abstract class MultiInputSingleOutput<I, O> extends BaseOperator {
     }
   }
 
-  public MultiInputSingleOutput() throws InstantiationException {
+  public MultiInputSingleOutput() throws InstantiationException
+  {
     this(DEFAULT_NUM_INPUTS);
   }
 

--- a/library/src/main/java/com/datatorrent/lib/simple/MultiInputSingleOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/simple/MultiInputSingleOutput.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.simple;
 
 import java.util.ArrayList;

--- a/library/src/main/java/com/datatorrent/lib/simple/SingleInputMultiOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/simple/SingleInputMultiOutput.java
@@ -1,0 +1,72 @@
+package com.datatorrent.lib.simple;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.annotation.Name;
+import com.datatorrent.api.annotation.Stateless;
+import com.datatorrent.common.util.BaseOperator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A base implementation of an operator that abstracts away the input and output ports.
+ *
+ * Subclasses should provide the implementation to process a tuple of type I and return a tuple of
+ * type O such that the return value will emit to each output port in the array.
+ *
+ * <p>
+ * <b>Input Port :</b><br>
+ * <b> input :</b> default input port. <br>
+ * <br>
+ * <b>Output Port(s) :</b><br>
+ * <b> output[] :</b> output port list that defaults to two ports. <br>
+ * <br>
+ * <b>Stateful : No</b>, all state is handled through the implementing class. <br>
+ * <b>Partitions : Yes</b>, no dependency among input tuples. <br>
+ * <br>
+ * @displayName Single Input With Multiple Output
+ * @category Simple Operators
+ * @tags simple, single input, multiple output
+ * @param <I> type being received from the input port
+ * @param <O> type being sent from the output port
+ * @since 3.3.0
+ */
+@Stateless
+@Name("single-input-multi-output")
+public abstract class SingleInputMultiOutput<I, O> extends BaseOperator {
+  protected static final int DEFAULT_NUM_OUTPUTS = 2;
+
+  protected transient List<DefaultOutputPort<O>> outputs = null;
+
+  protected transient final DefaultInputPort<I> input = new DefaultInputPort<I>() {
+    @Override
+    public void process(I inputTuple) {
+      O result;
+      if((result = SingleInputMultiOutput.this.process(inputTuple)) != null) {
+        for(int i = 0; i < outputs.size(); ++i) {
+          outputs.get(i).emit(result);
+        }
+      }
+    }
+  };
+
+  public SingleInputMultiOutput(int numOutputs) throws InstantiationException {
+    if (numOutputs < 1 || numOutputs > 65535) {
+      throw new InstantiationException("Cannot instantiate with "+numOutputs+
+          "; must be 1 < numOutputs < 65535");
+    } else {
+      this.outputs = new ArrayList<DefaultOutputPort<O>>(numOutputs);
+
+      for (int i = 0; i < numOutputs; ++i) {
+        this.outputs.add(new DefaultOutputPort<O>());
+      }
+    }
+  }
+
+  public SingleInputMultiOutput() throws InstantiationException {
+    this(DEFAULT_NUM_OUTPUTS);
+  }
+
+  public abstract O process(I inputTuple);
+}

--- a/library/src/main/java/com/datatorrent/lib/simple/SingleInputMultiOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/simple/SingleInputMultiOutput.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.simple;
 
 import java.util.ArrayList;

--- a/library/src/main/java/com/datatorrent/lib/simple/SingleInputMultiOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/simple/SingleInputMultiOutput.java
@@ -1,13 +1,13 @@
 package com.datatorrent.lib.simple;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.datatorrent.api.DefaultInputPort;
 import com.datatorrent.api.DefaultOutputPort;
 import com.datatorrent.api.annotation.Name;
 import com.datatorrent.api.annotation.Stateless;
 import com.datatorrent.common.util.BaseOperator;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A base implementation of an operator that abstracts away the input and output ports.
@@ -34,26 +34,29 @@ import java.util.List;
  */
 @Stateless
 @Name("single-input-multi-output")
-public abstract class SingleInputMultiOutput<I, O> extends BaseOperator {
+public abstract class SingleInputMultiOutput<I, O> extends BaseOperator
+{
   protected static final int DEFAULT_NUM_OUTPUTS = 2;
 
   protected transient List<DefaultOutputPort<O>> outputs = null;
 
-  protected transient final DefaultInputPort<I> input = new DefaultInputPort<I>() {
+  protected final transient DefaultInputPort<I> input = new DefaultInputPort<I>() {
     @Override
-    public void process(I inputTuple) {
+    public void process(I inputTuple)
+    {
       O result;
-      if((result = SingleInputMultiOutput.this.process(inputTuple)) != null) {
-        for(int i = 0; i < outputs.size(); ++i) {
+      if ((result = SingleInputMultiOutput.this.process(inputTuple)) != null) {
+        for (int i = 0; i < outputs.size(); ++i) {
           outputs.get(i).emit(result);
         }
       }
     }
   };
 
-  public SingleInputMultiOutput(int numOutputs) throws InstantiationException {
+  public SingleInputMultiOutput(int numOutputs) throws InstantiationException
+  {
     if (numOutputs < 1 || numOutputs > 65535) {
-      throw new InstantiationException("Cannot instantiate with "+numOutputs+
+      throw new InstantiationException("Cannot instantiate with " + numOutputs +
           "; must be 1 < numOutputs < 65535");
     } else {
       this.outputs = new ArrayList<DefaultOutputPort<O>>(numOutputs);
@@ -64,7 +67,8 @@ public abstract class SingleInputMultiOutput<I, O> extends BaseOperator {
     }
   }
 
-  public SingleInputMultiOutput() throws InstantiationException {
+  public SingleInputMultiOutput() throws InstantiationException
+  {
     this(DEFAULT_NUM_OUTPUTS);
   }
 

--- a/library/src/main/java/com/datatorrent/lib/simple/SingleInputOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/simple/SingleInputOutput.java
@@ -1,0 +1,44 @@
+package com.datatorrent.lib.simple;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.annotation.Name;
+import com.datatorrent.api.annotation.Stateless;
+import com.datatorrent.common.util.BaseOperator;
+
+/**
+ * A base implementation of an operator that abstracts away the input and output port.
+ *
+ * Subclasses should provide the implementation to process a tuple of type I and return a tuple of
+ * type O.
+ *
+ * <p>
+ * <b>Input Port :</b><br>
+ * <b> input :</b> default input port. <br>
+ * <br>
+ * <b>Output Port :</b><br>
+ * <b> output :</b> default output port. <br>
+ * <br>
+ * <b>Stateful : No</b>, all state is handled through the implementing class. <br>
+ * <b>Partitions : Yes</b>, no dependency among input tuples. <br>
+ * <br>
+ * @displayName Single Input & Output
+ * @category Simple Operators
+ * @tags simple, single input, single output
+ * @param <I> type being received from the input port
+ * @param <O> type being sent from the output port
+ * @since 3.3.0
+ */
+@Stateless
+@Name("single-input-output")
+public abstract class SingleInputOutput<I, O> extends BaseOperator {
+  protected transient final DefaultOutputPort<O> output = new DefaultOutputPort<O>();
+  protected transient final DefaultInputPort<I> input = new DefaultInputPort<I>() {
+    @Override
+    public void process(I inputTuple) {
+      output.emit(SingleInputOutput.this.process(inputTuple));
+    }
+  };
+
+  abstract O process(I inputTuple);
+}

--- a/library/src/main/java/com/datatorrent/lib/simple/SingleInputOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/simple/SingleInputOutput.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.simple;
 
 import com.datatorrent.api.DefaultInputPort;

--- a/library/src/main/java/com/datatorrent/lib/simple/SingleInputOutput.java
+++ b/library/src/main/java/com/datatorrent/lib/simple/SingleInputOutput.java
@@ -31,11 +31,13 @@ import com.datatorrent.common.util.BaseOperator;
  */
 @Stateless
 @Name("single-input-output")
-public abstract class SingleInputOutput<I, O> extends BaseOperator {
-  protected transient final DefaultOutputPort<O> output = new DefaultOutputPort<O>();
-  protected transient final DefaultInputPort<I> input = new DefaultInputPort<I>() {
+public abstract class SingleInputOutput<I, O> extends BaseOperator
+{
+  protected final transient DefaultOutputPort<O> output = new DefaultOutputPort<O>();
+  protected final transient DefaultInputPort<I> input = new DefaultInputPort<I>() {
     @Override
-    public void process(I inputTuple) {
+    public void process(I inputTuple)
+    {
       output.emit(SingleInputOutput.this.process(inputTuple));
     }
   };

--- a/library/src/test/java/com/datatorrent/lib/complex/AllWayMultiInputListOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/complex/AllWayMultiInputListOutputTest.java
@@ -1,0 +1,216 @@
+package com.datatorrent.lib.complex;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.lib.testbench.CollectorTestSink;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class AllWayMultiInputListOutputTest {
+  /**
+   * Test node logic emits correct results
+   */
+  @Test
+  public void testNodeProcessing() throws Exception {
+    List<Integer> inputSizes =
+        new ArrayList<Integer>(Arrays.asList(AllWayMultiInputListOutput.DEFAULT_NUM_INPUTS, 10, 100));
+    List<Integer> outputSizes =
+        new ArrayList<Integer>(Arrays.asList(AllWayMultiInputListOutput.DEFAULT_NUM_OUTPUTS, 10, 100));
+    List<Integer> valueSizes =
+        new ArrayList<Integer>(Arrays.asList(10, 1000));
+
+    // Test against the default constructor
+    testOperator(valueSizes.get(0));
+
+    // Test against the test matrix for this operator
+    for(Integer input : inputSizes) {
+      for(Integer output : outputSizes) {
+        for(Integer value : valueSizes) {
+          testOperator(input, output, value);
+        }
+      }
+    }
+  }
+
+  /**
+   * Test invalid operator instantiation with negative value for input ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testNegativeInputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputListOutput<String, Integer> oper = new AllWayMultiInputListOutput<String, Integer>(-1, 1) {
+      @Override
+      public List<Integer> process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with positive value for input ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testPositiveInputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputListOutput<String, Integer> oper = new AllWayMultiInputListOutput<String, Integer>(65536, 1) {
+      @Override
+      public List<Integer> process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with zero value for input ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testZeroInputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputListOutput<String, Integer> oper = new AllWayMultiInputListOutput<String, Integer>(0, 1) {
+      @Override
+      public List<Integer> process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with negative value for output ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testNegativeOutputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputListOutput<String, Integer> oper = new AllWayMultiInputListOutput<String, Integer>(1, -1) {
+      @Override
+      public List<Integer> process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with positive value for output ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testPositiveOutputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputListOutput<String, Integer> oper = new AllWayMultiInputListOutput<String, Integer>(1, 65536) {
+      @Override
+      public List<Integer> process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with zero value for output ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testZeroOutputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputListOutput<String, Integer> oper = new AllWayMultiInputListOutput<String, Integer>(1, 0) {
+      @Override
+      public List<Integer> process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test the default constructor.
+   *
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numValues) throws InstantiationException {
+    AllWayMultiInputListOutput<String, Integer> oper = new AllWayMultiInputListOutput<String, Integer>() {
+      List<Integer> results = new ArrayList<Integer>();
+
+      @Override
+      public List<Integer> process(String inputTuple) {
+        results.clear();
+
+        for (int i = 0; i < this.outputs.size(); ++i) {
+          results.add(i, Integer.parseInt(inputTuple) * i);
+        }
+
+        return results;
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  /**
+   * Test the various ways the operator could be constructed.
+   *
+   * @param numInputs number of inputs for the operator
+   * @param numOutputs number of outputs for the operator
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numInputs, int numOutputs, int numValues) throws
+      InstantiationException {
+    AllWayMultiInputListOutput<String, Integer> oper = new AllWayMultiInputListOutput<String, Integer>(numInputs, numOutputs) {
+      List<Integer> results = new ArrayList<Integer>();
+
+      @Override
+      public List<Integer> process(String inputTuple) {
+        results.clear();
+
+        for (int i = 0; i < this.outputs.size(); ++i) {
+          results.add(i, Integer.parseInt(inputTuple) * i);
+        }
+
+        return results;
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public void testOperator(AllWayMultiInputListOutput oper, int numValues) {
+    int numInputs = oper.inputs.size();
+    int numOutputs = oper.outputs.size();
+
+    int[] sumTotals = new int[numOutputs];
+    CollectorTestSink[] testSinks = new CollectorTestSink[numOutputs];
+
+    for(int i = 0; i < numOutputs; ++i) {
+      testSinks[i] = new CollectorTestSink();
+      ((DefaultOutputPort)oper.outputs.get(i)).setSink(testSinks[i]);
+    }
+
+    for(int i = 1; i <= numValues; ++i) {
+      for(int j = 0; j < numInputs; ++j) {
+        ((DefaultInputPort)oper.inputs.get(j)).process(Integer.toString(i));
+      }
+    }
+
+    for(int i = 0; i < numOutputs; ++i) {
+      Assert.assertEquals("number emitted tuples", numValues * numInputs,
+          testSinks[i].collectedTuples.size());
+
+      sumTotals[i] = 0;
+      for(Object tuple : testSinks[i].collectedTuples) {
+        sumTotals[i] += (Integer)tuple;
+      }
+
+      Assert.assertEquals("correct values", ((i + (numValues * i)) * (numValues / 2)) * numInputs, sumTotals[i]);
+    }
+
+    for(int i = 0; i < numOutputs; ++i) {
+      testSinks[i].clear();
+    }
+  }
+}

--- a/library/src/test/java/com/datatorrent/lib/complex/AllWayMultiInputListOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/complex/AllWayMultiInputListOutputTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.complex;
 
 import com.datatorrent.api.DefaultInputPort;

--- a/library/src/test/java/com/datatorrent/lib/complex/AllWayMultiInputOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/complex/AllWayMultiInputOutputTest.java
@@ -1,0 +1,199 @@
+package com.datatorrent.lib.complex;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.lib.testbench.CollectorTestSink;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class AllWayMultiInputOutputTest {
+  /**
+   * Test node logic emits correct results
+   */
+  @Test
+  public void testNodeProcessing() throws Exception {
+    List<Integer> inputSizes =
+        new ArrayList<Integer>(Arrays.asList(AllWayMultiInputOutput.DEFAULT_NUM_INPUTS, 10, 100));
+    List<Integer> outputSizes =
+        new ArrayList<Integer>(Arrays.asList(AllWayMultiInputOutput.DEFAULT_NUM_OUTPUTS, 10, 100));
+    List<Integer> valueSizes =
+        new ArrayList<Integer>(Arrays.asList(10, 1000));
+
+    // Test against the default constructor
+    testOperator(valueSizes.get(0));
+
+    // Test against the test matrix for this operator
+    for(Integer input : inputSizes) {
+      for(Integer output : outputSizes) {
+        for(Integer value : valueSizes) {
+          testOperator(input, output, value);
+        }
+      }
+    }
+  }
+
+  /**
+   * Test invalid operator instantiation with negative value for input ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testNegativeInputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputOutput<String, Integer> oper = new AllWayMultiInputOutput<String, Integer>(-1, 1) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with positive value for input ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testPositiveInputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputOutput<String, Integer> oper = new AllWayMultiInputOutput<String, Integer>(65536, 1) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with zero value for input ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testZeroInputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputOutput<String, Integer> oper = new AllWayMultiInputOutput<String, Integer>(0, 1) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with negative value for output ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testNegativeOutputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputOutput<String, Integer> oper = new AllWayMultiInputOutput<String, Integer>(1, -1) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with positive value for output ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testPositiveOutputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputOutput<String, Integer> oper = new AllWayMultiInputOutput<String, Integer>(1, 65536) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with zero value for output ports.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testZeroOutputOperatorInstantiation() throws InstantiationException {
+    AllWayMultiInputOutput<String, Integer> oper = new AllWayMultiInputOutput<String, Integer>(1, 0) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test the default constructor.
+   *
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numValues) throws InstantiationException {
+    AllWayMultiInputOutput<String, Integer> oper = new AllWayMultiInputOutput<String, Integer>() {
+      @Override
+      public Integer process(String inputTuple) {
+        return Integer.parseInt(inputTuple);
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  /**
+   * Test the various ways the operator could be constructed.
+   *
+   * @param numInputs number of inputs for the operator
+   * @param numOutputs number of outputs for the operator
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numInputs, int numOutputs, int numValues) throws
+      InstantiationException {
+    AllWayMultiInputOutput<String, Integer> oper = new AllWayMultiInputOutput<String, Integer>(numInputs, numOutputs) {
+      @Override
+      public Integer process(String inputTuple) {
+        return Integer.parseInt(inputTuple);
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public void testOperator(AllWayMultiInputOutput oper, int numValues) {
+    int numInputs = oper.inputs.size();
+    int numOutputs = oper.outputs.size();
+
+    int[] sumTotals = new int[numOutputs];
+    CollectorTestSink[] testSinks = new CollectorTestSink[numOutputs];
+
+    for(int i = 0; i < numOutputs; ++i) {
+      testSinks[i] = new CollectorTestSink();
+      ((DefaultOutputPort)oper.outputs.get(i)).setSink(testSinks[i]);
+    }
+
+    for(int i = 1; i <= numValues; ++i) {
+      for(int j = 0; j < numInputs; ++j) {
+        ((DefaultInputPort)oper.inputs.get(j)).process(Integer.toString(i));
+      }
+    }
+
+    for(int i = 0; i < numOutputs; ++i) {
+      Assert.assertEquals("number emitted tuples", numValues * numInputs, testSinks[i].collectedTuples.size());
+
+      sumTotals[i] = 0;
+      for(Object tuple : testSinks[i].collectedTuples) {
+        sumTotals[i] += (Integer)tuple;
+      }
+
+      Assert.assertEquals("correct values", ((1 + numValues) * (numValues / 2)) * numInputs, sumTotals[i]);
+    }
+
+    for(int i = 0; i < numOutputs; ++i) {
+      testSinks[i].clear();
+    }
+  }
+}

--- a/library/src/test/java/com/datatorrent/lib/complex/AllWayMultiInputOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/complex/AllWayMultiInputOutputTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.complex;
 
 import com.datatorrent.api.DefaultInputPort;

--- a/library/src/test/java/com/datatorrent/lib/complex/DirectMultiInputOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/complex/DirectMultiInputOutputTest.java
@@ -1,0 +1,147 @@
+package com.datatorrent.lib.complex;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.lib.testbench.CollectorTestSink;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class DirectMultiInputOutputTest {
+  /**
+   * Test node logic emits correct results
+   */
+  @Test
+  public void testNodeProcessing() throws Exception {
+    List<Integer> inputOutputSizes =
+        new ArrayList<Integer>(Arrays.asList(DirectMultiInputOutput.DEFAULT_NUM_INPUTS_OUTPUTS, 10, 100));
+    List<Integer> valueSizes =
+        new ArrayList<Integer>(Arrays.asList(10, 1000));
+
+    // Test against the default constructor
+    testOperator(valueSizes.get(0));
+
+    // Test against the test matrix for this operator
+    for(Integer inputOutput : inputOutputSizes) {
+      for(Integer value : valueSizes) {
+        testOperator(inputOutput, value);
+      }
+    }
+  }
+
+  /**
+   * Test invalid operator instantiation with negative value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testNegativeOperatorInstantiation() throws InstantiationException {
+    DirectMultiInputOutput<String, Integer> oper = new DirectMultiInputOutput<String, Integer>(-1) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with positive value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testPositiveOperatorInstantiation() throws InstantiationException {
+    DirectMultiInputOutput<String, Integer> oper = new DirectMultiInputOutput<String, Integer>(65536) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with zero value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testZeroOperatorInstantiation() throws InstantiationException {
+    DirectMultiInputOutput<String, Integer> oper = new DirectMultiInputOutput<String, Integer>(0) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test the default constructor.
+   *
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numValues) throws InstantiationException {
+    DirectMultiInputOutput<String, Integer> oper = new DirectMultiInputOutput<String, Integer>() {
+      @Override
+      public Integer process(String inputTuple) {
+        return Integer.parseInt(inputTuple);
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  /**
+   * Test the various ways the operator could be constructed.
+   *
+   * @param numInputsOutputs number of inputs and outputs for the operator
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numInputsOutputs, int numValues) throws InstantiationException {
+    DirectMultiInputOutput<String, Integer> oper = new DirectMultiInputOutput<String, Integer>(numInputsOutputs) {
+      @Override
+      public Integer process(String inputTuple) {
+        return Integer.parseInt(inputTuple);
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public void testOperator(DirectMultiInputOutput oper, int numValues) {
+    int numInputsOutputs = oper.inputs.size();
+
+    int[] sumTotals = new int[numInputsOutputs];
+    CollectorTestSink[] testSinks = new CollectorTestSink[numInputsOutputs];
+
+    for(int i = 0; i < numInputsOutputs; ++i) {
+      testSinks[i] = new CollectorTestSink();
+      ((DefaultOutputPort)oper.outputs.get(i)).setSink(testSinks[i]);
+    }
+
+    for(int i = 1; i <= numValues; ++i) {
+      for(int j = 0; j < numInputsOutputs; ++j) {
+        ((DefaultInputPort)oper.inputs.get(j)).process(Integer.toString(i));
+      }
+    }
+
+    for(int i = 0; i < numInputsOutputs; ++i) {
+      Assert.assertEquals("number emitted tuples", numValues, testSinks[i].collectedTuples.size());
+
+      sumTotals[i] = 0;
+      for(int j = 0; j < numValues; ++j) {
+        sumTotals[i] += (Integer)testSinks[i].collectedTuples.get(j);
+      }
+
+      Assert.assertEquals("correct values", (1 + numValues) * (numValues / 2), sumTotals[i]);
+    }
+
+    for(int i = 0; i < numInputsOutputs; ++i) {
+      testSinks[i].clear();
+    }
+  }
+}

--- a/library/src/test/java/com/datatorrent/lib/complex/DirectMultiInputOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/complex/DirectMultiInputOutputTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.complex;
 
 import com.datatorrent.api.DefaultInputPort;

--- a/library/src/test/java/com/datatorrent/lib/complex/SingleInputListOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/complex/SingleInputListOutputTest.java
@@ -1,0 +1,160 @@
+package com.datatorrent.lib.complex;
+
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.lib.testbench.CollectorTestSink;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SingleInputListOutputTest {
+  /**
+   * Test node logic emits correct results
+   */
+  @Test
+  public void testNodeProcessing() throws Exception {
+    List<Integer> outputSizes =
+        new ArrayList<Integer>(Arrays.asList(SingleInputListOutput.DEFAULT_NUM_OUTPUTS, 10, 100));
+    List<Integer> valueSizes =
+        new ArrayList<Integer>(Arrays.asList(10, 1000));
+
+    // Test against the default constructor
+    testOperator(valueSizes.get(0));
+
+    // Test against the test matrix for this operator
+    for(Integer output : outputSizes) {
+      for(Integer value : valueSizes) {
+        testOperator(output, value);
+      }
+    }
+  }
+
+  /**
+   * Test invalid operator instantiation with negative value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testNegativeOperatorInstantiation() throws InstantiationException {
+    SingleInputListOutput<String, Integer> oper = new SingleInputListOutput<String, Integer>(-1) {
+      @Override
+      public List<Integer> process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with positive value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testPositiveOperatorInstantiation() throws InstantiationException {
+    SingleInputListOutput<String, Integer> oper = new SingleInputListOutput<String, Integer>(65536) {
+      @Override
+      public List<Integer> process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with zero value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testZeroOperatorInstantiation() throws InstantiationException {
+    SingleInputListOutput<String, Integer> oper = new SingleInputListOutput<String, Integer>(0) {
+      @Override
+      public List<Integer> process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test the default constructor.
+   *
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numValues) throws InstantiationException {
+    SingleInputListOutput<String, Integer> oper = new SingleInputListOutput<String, Integer>() {
+      List<Integer> results = new ArrayList<Integer>(this.outputs.size());
+
+      @Override
+      public List<Integer> process(String inputTuple) {
+        results.clear();
+
+        for (int i = 0; i < this.outputs.size(); ++i) {
+          results.add(i, Integer.parseInt(inputTuple) * i);
+        }
+
+        return results;
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  /**
+   * Test the various ways the operator could be constructed.
+   *
+   * @param numOutputs number of outputs for the operator
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numOutputs, int numValues) throws InstantiationException {
+    SingleInputListOutput<String, Integer> oper = new SingleInputListOutput<String, Integer>(numOutputs) {
+      List<Integer> results = new ArrayList<Integer>(this.outputs.size());
+
+      @Override
+      public List<Integer> process(String inputTuple) {
+        results.clear();
+
+        for (int i = 0; i < this.outputs.size(); ++i) {
+          results.add(i, Integer.parseInt(inputTuple) * i);
+        }
+
+        return results;
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public void testOperator(SingleInputListOutput oper, int numValues) {
+    int numOutputs = oper.outputs.size();
+
+    int[] sumTotals = new int[numOutputs];
+    CollectorTestSink[] testSinks = new CollectorTestSink[numOutputs];
+
+    for(int i = 0; i < numOutputs; ++i) {
+      testSinks[i] = new CollectorTestSink();
+      ((DefaultOutputPort)oper.outputs.get(i)).setSink(testSinks[i]);
+    }
+
+    for(int i = 1; i <= numValues; ++i) {
+      oper.input.process(Integer.toString(i));
+    }
+
+    for(int i = 0; i < numOutputs; ++i) {
+      Assert.assertEquals("number emitted tuples", numValues, testSinks[i].collectedTuples.size());
+
+      sumTotals[i] = 0;
+      for(int j = 0; j < numValues; ++j) {
+        sumTotals[i] += (Integer)testSinks[i].collectedTuples.get(j);
+      }
+
+      Assert.assertEquals("correct values", (i + (numValues * i)) * (numValues / 2), sumTotals[i]);
+    }
+
+    for(int i = 0; i < numOutputs; ++i) {
+      testSinks[i].clear();
+    }
+  }
+}

--- a/library/src/test/java/com/datatorrent/lib/complex/SingleInputListOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/complex/SingleInputListOutputTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.complex;
 
 import com.datatorrent.api.DefaultOutputPort;

--- a/library/src/test/java/com/datatorrent/lib/simple/MultiInputSingleOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/simple/MultiInputSingleOutputTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.simple;
 
 import com.datatorrent.api.DefaultInputPort;

--- a/library/src/test/java/com/datatorrent/lib/simple/MultiInputSingleOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/simple/MultiInputSingleOutputTest.java
@@ -1,0 +1,146 @@
+package com.datatorrent.lib.simple;
+
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.lib.testbench.CollectorTestSink;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.junit.Assert;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class MultiInputSingleOutputTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  /**
+   * Test node logic emits correct results
+   */
+  @Test
+  public void testNodeProcessing() throws Exception {
+    List<Integer> inputSizes =
+        new ArrayList<Integer>(
+            Arrays.asList(MultiInputSingleOutput.DEFAULT_NUM_INPUTS, 10, 100));
+    List<Integer> valueSizes =
+        new ArrayList<Integer>(Arrays.asList(10, 1000));
+
+    // Test against the default constructor
+    testOperator(valueSizes.get(0));
+
+    // Test against the test matrix for this operator
+    for(Integer input : inputSizes) {
+      for (Integer value : valueSizes) {
+        testOperator(input, value);
+      }
+    }
+  }
+
+  /**
+   * Test invalid operator instantiation with negative value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testNegativeOperatorInstantiation() throws InstantiationException {
+    MultiInputSingleOutput<String, Integer> oper = new MultiInputSingleOutput<String, Integer>(-1) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with positive value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testPositiveOperatorInstantiation() throws InstantiationException {
+    MultiInputSingleOutput<String, Integer> oper = new MultiInputSingleOutput<String, Integer>(65536) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with zero value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testZeroOperatorInstantiation() throws InstantiationException {
+    MultiInputSingleOutput<String, Integer> oper = new MultiInputSingleOutput<String, Integer>(0) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test the default constructor.
+   *
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numValues) throws InstantiationException {
+    MultiInputSingleOutput<String, Integer> oper = new MultiInputSingleOutput<String, Integer>() {
+      @Override
+      public Integer process(String inputTuple) {
+        return Integer.parseInt(inputTuple);
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  /**
+   * Test the various ways the operator could be constructed.
+   *
+   * @param numInputs number of inputs for the operator
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numInputs, int numValues) throws InstantiationException {
+    MultiInputSingleOutput<String, Integer> oper = new MultiInputSingleOutput<String, Integer>(numInputs) {
+      @Override
+      public Integer process(String inputTuple) {
+        return Integer.parseInt(inputTuple);
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public void testOperator(MultiInputSingleOutput oper, int numValues) {
+    int numInputs = oper.inputs.size();
+    int sumTotal = 0;
+
+    CollectorTestSink testSink = new CollectorTestSink();
+    oper.output.setSink(testSink);
+
+    for(int i = 1; i <= numValues; ++i) {
+      for(int j = 0; j < numInputs; ++j) {
+        ((DefaultInputPort)oper.inputs.get(j)).process(Integer.toString(i));
+      }
+    }
+
+    int numTuples = numInputs * numValues;
+
+    Assert.assertEquals("number emitted tuples", numTuples, testSink.collectedTuples.size());
+
+    for(int i = 0; i < numTuples; ++i) {
+      sumTotal += (Integer)testSink.collectedTuples.get(i);
+    }
+
+    Assert.assertEquals("correct values", ((numValues * (numValues + 1)) / 2) * numInputs, sumTotal);
+
+    testSink.clear();
+  }
+}

--- a/library/src/test/java/com/datatorrent/lib/simple/SingleInputMultiOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/simple/SingleInputMultiOutputTest.java
@@ -1,0 +1,145 @@
+package com.datatorrent.lib.simple;
+
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.lib.testbench.CollectorTestSink;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SingleInputMultiOutputTest {
+  /**
+   * Test node logic emits correct results
+   */
+  @Test
+  public void testNodeProcessing() throws Exception {
+    List<Integer> outputSizes =
+        new ArrayList<Integer>(
+            Arrays.asList(SingleInputMultiOutput.DEFAULT_NUM_OUTPUTS, 10, 100));
+    List<Integer> valueSizes =
+        new ArrayList<Integer>(Arrays.asList(10, 1000));
+
+    // Test against the default constructor
+    testOperator(valueSizes.get(0));
+
+    // Test against the test matrix for this operator
+    for(Integer output : outputSizes) {
+      for (Integer value : valueSizes) {
+        testOperator(output, value);
+      }
+    }
+  }
+
+  /**
+   * Test invalid operator instantiation with negative value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testNegativeOperatorInstantiation() throws InstantiationException {
+    SingleInputMultiOutput<String, Integer> oper = new SingleInputMultiOutput<String, Integer>(-1) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with positive value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testPositiveOperatorInstantiation() throws InstantiationException {
+    SingleInputMultiOutput<String, Integer> oper = new SingleInputMultiOutput<String, Integer>(65536) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test invalid operator instantiation with zero value.
+   *
+   * @throws InstantiationException
+   */
+  @Test(expected=InstantiationException.class)
+  public void testZeroOperatorInstantiation() throws InstantiationException {
+    SingleInputMultiOutput<String, Integer> oper = new SingleInputMultiOutput<String, Integer>(0) {
+      @Override
+      public Integer process(String inputTuple) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Test the default constructor.
+   *
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(int numValues) throws InstantiationException {
+    SingleInputMultiOutput<String, Integer> oper = new SingleInputMultiOutput<String, Integer>() {
+      @Override
+      public Integer process(String inputTuple) {
+        return Integer.parseInt(inputTuple);
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  /**
+   * Test the various ways the operator could be constructed.
+   *
+   * @param numOutputs number of outputs for the operator
+   * @param numValues number of tuples to process for the test
+   */
+  public void testOperator(final int numOutputs, int numValues) throws InstantiationException {
+    SingleInputMultiOutput<String, Integer> oper = new SingleInputMultiOutput<String, Integer>(numOutputs) {
+      @Override
+      public Integer process(String inputTuple) {
+        return Integer.parseInt(inputTuple);
+      }
+    };
+
+    testOperator(oper, numValues);
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public void testOperator(SingleInputMultiOutput oper, int numValues) {
+    int numOutputs = oper.outputs.size();
+
+    int[] sumTotals = new int[numOutputs];
+    CollectorTestSink[] testSinks = new CollectorTestSink[numOutputs];
+
+    for(int i = 0; i < numOutputs; ++i) {
+      testSinks[i] = new CollectorTestSink();
+      ((DefaultOutputPort)oper.outputs.get(i)).setSink(testSinks[i]);
+    }
+
+    for(int i = 1; i <= numValues; ++i) {
+      oper.input.process(Integer.toString(i));
+    }
+
+    for(int i = 0; i < numOutputs; ++i) {
+      Assert.assertEquals("number emitted tuples", numValues, testSinks[i].collectedTuples.size());
+
+      sumTotals[i] = 0;
+      for(int j = 0; j < numValues; ++j) {
+        sumTotals[i] += (Integer)testSinks[i].collectedTuples.get(j);
+      }
+
+      Assert.assertEquals("correct values", (1 + numValues) * (numValues / 2), sumTotals[i]);
+    }
+
+    for(int i = 0; i < numOutputs; ++i) {
+      testSinks[i].clear();
+    }
+  }
+}

--- a/library/src/test/java/com/datatorrent/lib/simple/SingleInputMultiOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/simple/SingleInputMultiOutputTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.simple;
 
 import com.datatorrent.api.DefaultOutputPort;

--- a/library/src/test/java/com/datatorrent/lib/simple/SingleInputOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/simple/SingleInputOutputTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.simple;
 
 import com.datatorrent.lib.testbench.CollectorTestSink;

--- a/library/src/test/java/com/datatorrent/lib/simple/SingleInputOutputTest.java
+++ b/library/src/test/java/com/datatorrent/lib/simple/SingleInputOutputTest.java
@@ -1,0 +1,38 @@
+package com.datatorrent.lib.simple;
+
+import com.datatorrent.lib.testbench.CollectorTestSink;
+
+import org.junit.Test;
+
+import org.junit.Assert;
+
+public class SingleInputOutputTest {
+  int numValues = 100;
+  /**
+   * Test node logic emits correct results
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  @Test
+  public void testNodeProcessing() throws Exception {
+    SingleInputOutput<String, Integer> oper = new SingleInputOutput<String, Integer>() {
+      @Override
+      Integer process(String inputTuple) {
+        return Integer.parseInt(inputTuple);
+      }
+    };
+    CollectorTestSink testSink = new CollectorTestSink();
+    oper.output.setSink(testSink);
+
+    for(int i = 0; i < numValues; ++i) {
+      oper.input.process(Integer.toString(i));
+    }
+
+    Assert.assertEquals("number emitted tuples", numValues, testSink.collectedTuples.size());
+
+    for(int i = 0; i < numValues; ++i) {
+      Assert.assertEquals("correct values", i, testSink.collectedTuples.get(i));
+    }
+
+    testSink.clear();
+  }
+}


### PR DESCRIPTION
Resolves base operators by adding a set of operator primitives with which developers can build from. This adds:
- `simple`
  - `SingleInputOutput`
  - `SingleInputMultiOutput`
  - `MultiInputSingleOutput`
- `complex`
  - `SingleInputListOutput`
  - `DirectMultiInputOutput`
  - `AllWayMultiInputOutput`
  - `AllWayMultiInputListOutput`
