### PR TITLE
APEXMALHAR-1967: JDBC Store setting connection properties from config file is broken

### DIFF
--- a/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcStoreTest.java
+++ b/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcStoreTest.java
@@ -36,9 +36,18 @@ public class JdbcStoreTest
   {
     JdbcStore store = new JdbcStore();
     store.setConnectionProperties("user:test,password:pwd");
-    Properties properties = store.getConnectionProperties();
+    Properties properties = store.getConnectionPropertiesList();
     Assert.assertEquals("user", properties.get("user"), "test");
     Assert.assertEquals("password", properties.get("password"), "pwd");
+  }
+
+  @Test
+  public void testConnectionPropertiesString()
+  {
+    String connectionProps = "user:test,password:pwd,connectTimeout:2000";
+    JdbcStore store = new JdbcStore();
+    store.setConnectionProperties(connectionProps);
+    Assert.assertEquals("Connection Properties", connectionProps, store.getConnectionProperties());
   }
 
   @Test


### PR DESCRIPTION
Operator had overloaded setter methods to set connection properties. This caused problems to BeanUtils to identify right setter. 
Renamed the method which accepts java Properties object to setConnectionPropertiesList.
Note: Did not change the method which accepts string as it's already been used in many properties file to set the connections properties.
