### PR TITLE
Apexmalhar-2008: hdfs file reader module

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/io/block/HDFSBlockMetadata.java
+++ b/library/src/main/java/com/datatorrent/lib/io/block/HDFSBlockMetadata.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.io.block;
 
 /**

--- a/library/src/main/java/com/datatorrent/lib/io/block/HDFSBlockMetadata.java
+++ b/library/src/main/java/com/datatorrent/lib/io/block/HDFSBlockMetadata.java
@@ -1,0 +1,45 @@
+package com.datatorrent.lib.io.block;
+
+/**
+ * HDFSBlockMetadata extends {@link BlockMetadata} to provide an option if blocks of a file should be read in-sequence
+ * or in-parallel
+ */
+public class HDFSBlockMetadata extends BlockMetadata.FileBlockMetadata
+{
+  boolean readBlockInSequence;
+
+  protected HDFSBlockMetadata()
+  {
+    super();
+  }
+
+  public HDFSBlockMetadata(String filePath, long blockId, long offset, long length, boolean isLastBlock, long previousBlockId)
+  {
+    super(filePath, blockId, offset, length, isLastBlock, previousBlockId);
+  }
+
+  public HDFSBlockMetadata(String filePath)
+  {
+    super(filePath);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    if (isReadBlockInSequence()) {
+      return getFilePath().hashCode();
+    }
+    return super.hashCode();
+  }
+
+  public boolean isReadBlockInSequence()
+  {
+    return readBlockInSequence;
+  }
+
+  public void setReadBlockInSequence(boolean readBlockInSequence)
+  {
+    this.readBlockInSequence = readBlockInSequence;
+  }
+
+}

--- a/library/src/main/java/com/datatorrent/lib/io/block/HDFSBlockReader.java
+++ b/library/src/main/java/com/datatorrent/lib/io/block/HDFSBlockReader.java
@@ -1,0 +1,59 @@
+package com.datatorrent.lib.io.block;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import com.google.common.base.Splitter;
+
+public class HDFSBlockReader extends FSSliceReader
+{
+  protected String uri;
+
+  @Override
+  protected FileSystem getFSInstance() throws IOException
+  {
+    return FileSystem.newInstance(URI.create(uri), configuration);
+  }
+
+  /**
+   * Sets the uri
+   *
+   * @param uri
+   */
+  public void setUri(String uri)
+  {
+    this.uri = convertSchemeToLowerCase(uri);
+  }
+
+  public String getUri()
+  {
+    return uri;
+  }
+
+  /**
+   * Converts Scheme part of the URI to lower case. Multiple URI can be comma separated. If no scheme is there, no
+   * change is made.
+   * 
+   * @param
+   * @return String with scheme part as lower case
+   */
+  private static String convertSchemeToLowerCase(String uri)
+  {
+    if (uri == null)
+      return null;
+    StringBuilder inputMod = new StringBuilder();
+    for (String f : Splitter.on(",").omitEmptyStrings().split(uri)) {
+      String scheme = URI.create(f).getScheme();
+      if (scheme != null) {
+        inputMod.append(f.replaceFirst(scheme, scheme.toLowerCase()));
+      } else {
+        inputMod.append(f);
+      }
+      inputMod.append(",");
+    }
+    inputMod.setLength(inputMod.length() - 1);
+    return inputMod.toString();
+  }
+}

--- a/library/src/main/java/com/datatorrent/lib/io/block/HDFSBlockReader.java
+++ b/library/src/main/java/com/datatorrent/lib/io/block/HDFSBlockReader.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.io.block;
 
 import java.io.IOException;

--- a/library/src/main/java/com/datatorrent/lib/io/fs/HDFSFileSplitter.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/HDFSFileSplitter.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.io.fs;
 
 import java.io.File;

--- a/library/src/main/java/com/datatorrent/lib/io/fs/HDFSFileSplitter.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/HDFSFileSplitter.java
@@ -1,0 +1,162 @@
+package com.datatorrent.lib.io.fs;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+
+import com.datatorrent.api.Context.OperatorContext;
+import com.datatorrent.lib.io.block.BlockMetadata.FileBlockMetadata;
+import com.datatorrent.lib.io.block.HDFSBlockMetadata;
+
+public class HDFSFileSplitter extends FileSplitterInput
+{
+  private boolean sequencialFileRead;
+
+  public HDFSFileSplitter()
+  {
+    super();
+    super.setScanner(new HDFSScanner());
+  }
+
+  @Override
+  protected FileMetadata createFileMetadata(FileInfo fileInfo)
+  {
+    return new HDFSFileMetaData(fileInfo.getFilePath());
+  }
+
+  @Override
+  protected HDFSFileMetaData buildFileMetadata(FileInfo fileInfo) throws IOException
+  {
+    FileMetadata metadata = super.buildFileMetadata(fileInfo);
+    HDFSFileMetaData hdfsFileMetaData = (HDFSFileMetaData) metadata;
+
+    Path path = new Path(fileInfo.getFilePath());
+    FileStatus status = getFileStatus(path);
+    if (fileInfo.getDirectoryPath() == null) { // Direct filename is given as input.
+      hdfsFileMetaData.setRelativePath(status.getPath().getName());
+    } else {
+      String relativePath = getRelativePathWithFolderName(fileInfo);
+      hdfsFileMetaData.setRelativePath(relativePath);
+    }
+    return hdfsFileMetaData;
+  }
+
+  /*
+   * As folder name was given to input for copy, prefix folder name to the sub items to copy.
+   */
+  private String getRelativePathWithFolderName(FileInfo fileInfo)
+  {
+    String parentDir = new Path(fileInfo.getDirectoryPath()).getName();
+    return parentDir + File.separator + fileInfo.getRelativeFilePath();
+  }
+
+  @Override
+  protected HDFSBlockMetadata createBlockMetadata(FileMetadata fileMetadata)
+  {
+    HDFSBlockMetadata blockMetadta = new HDFSBlockMetadata(fileMetadata.getFilePath());
+    blockMetadta.setReadBlockInSequence(sequencialFileRead);
+    return blockMetadta;
+  }
+
+  @Override
+  protected HDFSBlockMetadata buildBlockMetadata(long pos, long lengthOfFileInBlock, int blockNumber, FileMetadata fileMetadata, boolean isLast)
+  {
+    FileBlockMetadata metadata = super.buildBlockMetadata(pos, lengthOfFileInBlock, blockNumber, fileMetadata, isLast);
+    HDFSBlockMetadata blockMetadata = (HDFSBlockMetadata) metadata;
+    return blockMetadata;
+  }
+
+  public boolean isSequencialFileRead()
+  {
+    return sequencialFileRead;
+  }
+
+  public void setSequencialFileRead(boolean sequencialFileRead)
+  {
+    this.sequencialFileRead = sequencialFileRead;
+  }
+
+  public static class HDFSScanner extends TimeBasedDirectoryScanner
+  {
+    protected final static String HDFS_TEMP_FILE = ".*._COPYING_";
+    protected final static String UNSUPPORTED_CHARACTOR = ":";
+    private transient Pattern ignoreRegex;
+
+    @Override
+    public void setup(OperatorContext context)
+    {
+      super.setup(context);
+      ignoreRegex = Pattern.compile(HDFS_TEMP_FILE);
+    }
+
+    @Override
+    protected boolean acceptFile(String filePathStr)
+    {
+      boolean accepted = super.acceptFile(filePathStr);
+      if (containsUnsupportedCharacters(filePathStr) || isTempFile(filePathStr)) {
+        return false;
+      }
+      return accepted;
+    }
+
+    private boolean isTempFile(String filePathStr)
+    {
+      String fileName = new Path(filePathStr).getName();
+      if (ignoreRegex != null) {
+        Matcher matcher = ignoreRegex.matcher(fileName);
+        if (matcher.matches()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private boolean containsUnsupportedCharacters(String filePathStr)
+    {
+      return new Path(filePathStr).toUri().getPath().contains(UNSUPPORTED_CHARACTOR);
+    }
+  }
+
+  public static class HDFSFileMetaData extends FileMetadata
+  {
+    private String relativePath;
+
+    protected HDFSFileMetaData()
+    {
+      super();
+    }
+
+    public HDFSFileMetaData(@NotNull String filePath)
+    {
+      super(filePath);
+    }
+
+    public String getRelativePath()
+    {
+      return relativePath;
+    }
+
+    public void setRelativePath(String relativePath)
+    {
+      this.relativePath = relativePath;
+    }
+
+    @Override
+    public String toString()
+    {
+      return "HDFSFileMetaData [relativePath=" + relativePath + ", getNumberOfBlocks()=" + getNumberOfBlocks() + ", getFileName()=" + getFileName() + ", getFileLength()=" + getFileLength() + ", isDirectory()=" + isDirectory() + "]";
+    }
+
+    public String getOutputRelativePath()
+    {
+      return relativePath;
+    }
+
+  }
+}

--- a/library/src/main/java/com/datatorrent/lib/io/fs/HDFSInputModule.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/HDFSInputModule.java
@@ -1,0 +1,218 @@
+package com.datatorrent.lib.io.fs;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.apache.commons.lang.mutable.MutableLong;
+import org.apache.hadoop.conf.Configuration;
+
+import com.datatorrent.api.Context;
+import com.datatorrent.api.DAG;
+import com.datatorrent.api.Module;
+import com.datatorrent.common.metric.MetricsAggregator;
+import com.datatorrent.common.metric.SingleMetricAggregator;
+import com.datatorrent.common.metric.sum.LongSumAggregator;
+import com.datatorrent.common.partitioner.StatelessPartitioner;
+import com.datatorrent.lib.counters.BasicCounters;
+import com.datatorrent.lib.io.block.AbstractBlockReader.ReaderRecord;
+import com.datatorrent.lib.io.block.BlockMetadata.FileBlockMetadata;
+import com.datatorrent.lib.io.block.HDFSBlockReader;
+import com.datatorrent.lib.io.fs.AbstractFileSplitter.FileMetadata;
+import com.datatorrent.lib.io.fs.HDFSFileSplitter.HDFSScanner;
+import com.datatorrent.netlet.util.Slice;
+
+/**
+ * HDFSInputModule is used to read files from HDFS. <br/>
+ * Module emits FileMetadata, BlockMetadata and the block bytes.
+ */
+public class HDFSInputModule implements Module
+{
+
+  @NotNull
+  @Size(min = 1)
+  private String files;
+  private String filePatternRegularExp;
+  @Min(0)
+  private long scanIntervalMillis;
+  private boolean recursive = true;
+  private long blockSize;
+  private boolean sequencialFileRead = false;
+  private int readersCount;
+
+  public final transient ProxyOutputPort<FileMetadata> filesMetadataOutput = new ProxyOutputPort();
+  public final transient ProxyOutputPort<FileBlockMetadata> blocksMetadataOutput = new ProxyOutputPort();
+  public final transient ProxyOutputPort<ReaderRecord<Slice>> messages = new ProxyOutputPort();
+
+  @Override
+  public void populateDAG(DAG dag, Configuration conf)
+  {
+    HDFSFileSplitter fileSplitter = dag.addOperator("FileSplitter", new HDFSFileSplitter());
+    HDFSBlockReader blockReader = dag.addOperator("BlockReader", new HDFSBlockReader());
+
+    dag.addStream("BlockMetadata", fileSplitter.blocksMetadataOutput, blockReader.blocksMetadataInput);
+
+    filesMetadataOutput.set(fileSplitter.filesMetadataOutput);
+    blocksMetadataOutput.set(blockReader.blocksMetadataOutput);
+    messages.set(blockReader.messages);
+
+    fileSplitter.setSequencialFileRead(sequencialFileRead);
+    if (blockSize != 0) {
+      fileSplitter.setBlockSize(blockSize);
+    }
+
+    HDFSScanner fileScanner = (HDFSScanner) fileSplitter.getScanner();
+    fileScanner.setFiles(files);
+    if (scanIntervalMillis != 0) {
+      fileScanner.setScanIntervalMillis(scanIntervalMillis);
+    }
+    fileScanner.setRecursive(recursive);
+    if (filePatternRegularExp != null) {
+      fileSplitter.getScanner().setFilePatternRegularExp(filePatternRegularExp);
+    }
+
+    blockReader.setUri(files);
+    if (readersCount != 0) {
+      dag.setAttribute(blockReader, Context.OperatorContext.PARTITIONER, new StatelessPartitioner<HDFSBlockReader>(readersCount));
+    }
+
+    MetricsAggregator blockReaderMetrics = new MetricsAggregator();
+    blockReaderMetrics.addAggregators("bytesReadPerSec", new SingleMetricAggregator[] { new LongSumAggregator() });
+    dag.setAttribute(blockReader, Context.OperatorContext.METRICS_AGGREGATOR, blockReaderMetrics);
+    dag.setAttribute(blockReader, Context.OperatorContext.COUNTERS_AGGREGATOR, new BasicCounters.LongAggregator<MutableLong>());
+  }
+
+  /**
+   * A comma separated list of directories to scan. If the path is not fully qualified the default file system is used.
+   * A fully qualified path can be provided to scan directories in other filesystems.
+   *
+   * @param files
+   *          files
+   */
+  public void setFiles(String files)
+  {
+    this.files = files;
+  }
+
+  /**
+   * Gets the files to be scanned.
+   *
+   * @return files to be scanned.
+   */
+  public String getFiles()
+  {
+    return files;
+  }
+
+  /**
+   * Gets the regular expression for file names to split
+   *
+   * @return regular expression
+   */
+  public String getFilePatternRegularExp()
+  {
+    return filePatternRegularExp;
+  }
+
+  /**
+   * Only files with names matching the given java regular expression are split
+   *
+   * @param filePatternRegexp
+   *          regular expression
+   */
+  public void setFilePatternRegularExp(String filePatternRegexp)
+  {
+    this.filePatternRegularExp = filePatternRegexp;
+  }
+
+  /**
+   * Gets scan interval in milliseconds, interval between two scans to discover new files in input directory
+   *
+   * @return scanInterval milliseconds
+   */
+  public long getScanIntervalMillis()
+  {
+    return scanIntervalMillis;
+  }
+
+  /**
+   * Sets scan interval in milliseconds, interval between two scans to discover new files in input directory
+   *
+   * @param scanIntervalMillis
+   */
+  public void setScanIntervalMillis(long scanIntervalMillis)
+  {
+    this.scanIntervalMillis = scanIntervalMillis;
+  }
+
+  /**
+   * Get is scan recursive
+   *
+   * @return isRecursive
+   */
+  public boolean isRecursive()
+  {
+    return recursive;
+  }
+
+  /**
+   * set is scan recursive
+   *
+   * @param recursive
+   */
+  public void setRecursive(boolean recursive)
+  {
+    this.recursive = recursive;
+  }
+
+  /**
+   * Get block size used to read input blocks of file
+   *
+   * @return blockSize
+   */
+  public long getBlockSize()
+  {
+    return blockSize;
+  }
+
+  /**
+   * Sets block size used to read input blocks of file
+   *
+   * @param blockSize
+   */
+  public void setBlockSize(long blockSize)
+  {
+    this.blockSize = blockSize;
+  }
+
+  public int getReadersCount()
+  {
+    return readersCount;
+  }
+
+  public void setReadersCount(int readersCount)
+  {
+    this.readersCount = readersCount;
+  }
+
+  /**
+   * Gets is sequencial file read
+   * 
+   * @return
+   */
+  public boolean isSequencialFileRead()
+  {
+    return sequencialFileRead;
+  }
+
+  /**
+   * Sets is sequencial file read
+   *
+   * @param sequencialFileRead
+   */
+  public void setSequencialFileRead(boolean sequencialFileRead)
+  {
+    this.sequencialFileRead = sequencialFileRead;
+  }
+
+}

--- a/library/src/main/java/com/datatorrent/lib/io/fs/HDFSInputModule.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/HDFSInputModule.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.io.fs;
 
 import javax.validation.constraints.Min;

--- a/library/src/test/java/com/datatorrent/lib/io/fs/HDFSInputModuleAppTest.java
+++ b/library/src/test/java/com/datatorrent/lib/io/fs/HDFSInputModuleAppTest.java
@@ -153,7 +153,7 @@ class Application implements StreamingApplication
     metadataWriter.setFilePath(HDFSInputModuleAppTest.outputDir);
     dag.addOperator("FileMetadataWriter", metadataWriter);
 
-    AbstractFileOutputOperator<ReaderRecord<Slice>> dataWriter = new FileWriter(HDFSInputModuleAppTest.OUT_DATA_FILE);
+    AbstractFileOutputOperator<ReaderRecord<Slice>> dataWriter = new HDFSFileWriter(HDFSInputModuleAppTest.OUT_DATA_FILE);
     dataWriter.setFilePath(HDFSInputModuleAppTest.outputDir);
     dag.addOperator("FileDataWriter", dataWriter);
 
@@ -195,16 +195,16 @@ class MetadataWriter extends AbstractFileOutputOperator<FileMetadata>
   }
 }
 
-class FileWriter extends AbstractFileOutputOperator<ReaderRecord<Slice>>
+class HDFSFileWriter extends AbstractFileOutputOperator<ReaderRecord<Slice>>
 {
   String fileName;
 
   @SuppressWarnings("unused")
-  private FileWriter()
+  private HDFSFileWriter()
   {
   }
 
-  public FileWriter(String fileName)
+  public HDFSFileWriter(String fileName)
   {
     this.fileName = fileName;
   }

--- a/library/src/test/java/com/datatorrent/lib/io/fs/HDFSInputModuleAppTest.java
+++ b/library/src/test/java/com/datatorrent/lib/io/fs/HDFSInputModuleAppTest.java
@@ -1,0 +1,206 @@
+package com.datatorrent.lib.io.fs;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.datatorrent.api.DAG;
+import com.datatorrent.api.LocalMode;
+import com.datatorrent.api.StreamingApplication;
+import com.datatorrent.lib.io.block.AbstractBlockReader.ReaderRecord;
+import com.datatorrent.lib.io.block.BlockMetadata.FileBlockMetadata;
+import com.datatorrent.lib.io.fs.AbstractFileOutputOperator;
+import com.datatorrent.lib.io.fs.AbstractFileSplitter.FileMetadata;
+import com.datatorrent.lib.io.fs.HDFSFileSplitter.HDFSFileMetaData;
+import com.datatorrent.lib.stream.DevNull;
+import com.datatorrent.netlet.util.Slice;
+
+public class HDFSInputModuleAppTest
+{
+  private String inputDir;
+  static String outputDir;
+  private StreamingApplication app;
+  private static final String FILE_1 = "file1.txt";
+  private static final String FILE_2 = "file2.txt";
+  private static final String FILE_1_DATA = "File one data";
+  private static final String FILE_2_DATA = "File two data. This has more data hence more blocks.";
+  static final String OUT_DATA_FILE = "fileData.txt";
+  static final String OUT_METADATA_FILE = "fileMetaData.txt";
+
+  public static class TestMeta extends TestWatcher
+  {
+    public String baseDirectory;
+
+    @Override
+    protected void starting(org.junit.runner.Description description)
+    {
+      this.baseDirectory = "target/" + description.getClassName() + "/" + description.getMethodName();
+    }
+
+  }
+
+  @Rule
+  public TestMeta testMeta = new TestMeta();
+
+  @Before
+  public void setup() throws Exception
+  {
+    inputDir = testMeta.baseDirectory + File.separator + "input";
+    outputDir = testMeta.baseDirectory + File.separator + "output";
+
+    FileUtils.writeStringToFile(new File(inputDir + File.separator + FILE_1), FILE_1_DATA);
+    FileUtils.writeStringToFile(new File(inputDir + File.separator + FILE_2), FILE_2_DATA);
+    FileUtils.writeStringToFile(new File(inputDir + File.separator + "dir/inner.txt"), FILE_1_DATA);
+  }
+
+  @After
+  public void tearDown() throws IOException
+  {
+    FileUtils.deleteDirectory(new File(inputDir));
+  }
+
+  @Test
+  public void testApplication() throws Exception
+  {
+    app = new Application();
+    Configuration conf = new Configuration(false);
+    conf.set("dt.operator.hdfsInputModule.prop.files", inputDir);
+    conf.set("dt.operator.hdfsInputModule.prop.blockSize", "10");
+    conf.set("dt.operator.hdfsInputModule.prop.scanIntervalMillis", "10000");
+
+    LocalMode lma = LocalMode.newInstance();
+    lma.prepareDAG(app, conf);
+    LocalMode.Controller lc = lma.getController();
+    lc.setHeartbeatMonitoringEnabled(true);
+    lc.runAsync();
+
+    long now = System.currentTimeMillis();
+    Path outDir = new Path("file://" + new File(outputDir).getAbsolutePath());
+    FileSystem fs = FileSystem.newInstance(outDir.toUri(), new Configuration());
+    while (!fs.exists(outDir) && System.currentTimeMillis() - now < 20000) {
+      Thread.sleep(500);
+      LOG.debug("Waiting for {}", outDir);
+    }
+
+    Thread.sleep(10000);
+    lc.shutdown();
+
+    Assert.assertTrue("output dir does not exist", fs.exists(outDir));
+
+    File dir = new File(outputDir);
+    FileFilter fileFilter = new WildcardFileFilter(OUT_METADATA_FILE + "*");
+    verifyFileContents(dir.listFiles(fileFilter), "[relativePath=input/file1.txt, getNumberOfBlocks()=2, getFileName()=file1.txt, getFileLength()=13, isDirectory()=false]");
+    verifyFileContents(dir.listFiles(fileFilter), "[relativePath=input/file2.txt, getNumberOfBlocks()=6, getFileName()=file2.txt, getFileLength()=52, isDirectory()=false]");
+    verifyFileContents(dir.listFiles(fileFilter), "[relativePath=input/dir, getNumberOfBlocks()=0, getFileName()=dir, getFileLength()=4096, isDirectory()=true]");
+    verifyFileContents(dir.listFiles(fileFilter), "[relativePath=input/dir/inner.txt, getNumberOfBlocks()=2, getFileName()=inner.txt, getFileLength()=13, isDirectory()=false]");
+
+    fileFilter = new WildcardFileFilter(OUT_DATA_FILE + "*");
+    verifyFileContents(dir.listFiles(fileFilter), FILE_1_DATA);
+    verifyFileContents(dir.listFiles(fileFilter), FILE_2_DATA);
+  }
+
+  private void verifyFileContents(File[] files, String expectedData) throws IOException
+  {
+    StringBuilder filesData = new StringBuilder();
+    for (File file : files) {
+      filesData.append(FileUtils.readFileToString(file));
+    }
+    Assert.assertTrue("File data doesn't contain expected text", filesData.indexOf(expectedData) > -1);
+  }
+
+  private static Logger LOG = LoggerFactory.getLogger(HDFSInputModuleAppTest.class);
+}
+
+class Application implements StreamingApplication
+{
+  public void populateDAG(DAG dag, Configuration conf)
+  {
+    HDFSInputModule module = dag.addModule("hdfsInputModule", HDFSInputModule.class);
+
+    AbstractFileOutputOperator<FileMetadata> metadataWriter = new MetadataWriter(HDFSInputModuleAppTest.OUT_METADATA_FILE);
+    metadataWriter.setFilePath(HDFSInputModuleAppTest.outputDir);
+    dag.addOperator("FileMetadataWriter", metadataWriter);
+
+    AbstractFileOutputOperator<ReaderRecord<Slice>> dataWriter = new FileWriter(HDFSInputModuleAppTest.OUT_DATA_FILE);
+    dataWriter.setFilePath(HDFSInputModuleAppTest.outputDir);
+    dag.addOperator("FileDataWriter", dataWriter);
+
+    DevNull<FileBlockMetadata> devNull = dag.addOperator("devNull", DevNull.class);
+
+    dag.addStream("FileMetaData", module.filesMetadataOutput, metadataWriter.input);
+    dag.addStream("data", module.messages, dataWriter.input);
+    dag.addStream("blockMetadata", module.blocksMetadataOutput, devNull.data);
+  }
+}
+
+class MetadataWriter extends AbstractFileOutputOperator<FileMetadata>
+{
+  String fileName;
+
+  @SuppressWarnings("unused")
+  private MetadataWriter()
+  {
+
+  }
+
+  public MetadataWriter(String fileName)
+  {
+    this.fileName = fileName;
+  }
+
+  @Override
+  protected String getFileName(FileMetadata tuple)
+  {
+    return fileName;
+  }
+
+  @Override
+  protected byte[] getBytesForTuple(FileMetadata tuple)
+  {
+    String metadata = ((HDFSFileMetaData) tuple).toString();
+    System.out.println(metadata);
+    return ((HDFSFileMetaData) tuple).toString().getBytes();
+  }
+}
+
+class FileWriter extends AbstractFileOutputOperator<ReaderRecord<Slice>>
+{
+  String fileName;
+
+  @SuppressWarnings("unused")
+  private FileWriter()
+  {
+  }
+
+  public FileWriter(String fileName)
+  {
+    this.fileName = fileName;
+  }
+
+  @Override
+  protected String getFileName(ReaderRecord<Slice> tuple)
+  {
+    return fileName;
+  }
+
+  @Override
+  protected byte[] getBytesForTuple(ReaderRecord<Slice> tuple)
+  {
+    return tuple.getRecord().buffer;
+  }
+
+}

--- a/library/src/test/java/com/datatorrent/lib/io/fs/HDFSInputModuleAppTest.java
+++ b/library/src/test/java/com/datatorrent/lib/io/fs/HDFSInputModuleAppTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.datatorrent.lib.io.fs;
 
 import java.io.File;


### PR DESCRIPTION
Code to add HDFS file reader module. 
1. The module reads file/list of files (directory is also accepted) and emit the file blocks. 
2. The module can be configured to emit blocks in order or out of order.
3. Module reads file blocks in parallel. The number of parallel readers is configurable, if not configured it will increase or decrease readers dynamically as per input data rate.

Also updated code of FileSplitterInput to add some improvements:
1. Tracking last file reference times of each folder differently, to avoid duplicates (duplicates could be due to same relative paths of multiple files/sub dir)
2. Small improvements in code.
