### PR TITLE
APEXMALHAR-1953 Updated Jdbc Output Operator

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/db/AbstractTransactionableStoreOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/AbstractTransactionableStoreOutputOperator.java
@@ -24,6 +24,7 @@ import com.datatorrent.common.util.BaseOperator;
 import com.datatorrent.api.Context.OperatorContext;
 import com.datatorrent.api.DAG;
 import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
 import com.datatorrent.api.annotation.InputPortFieldAnnotation;
 
 /**
@@ -66,6 +67,8 @@ public abstract class AbstractTransactionableStoreOutputOperator<T, S extends Tr
     }
 
   };
+
+  public final transient DefaultOutputPort<T> error = new DefaultOutputPort<>();
 
   /**
    * Gets the store

--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/AbstractJdbcPOJOOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/AbstractJdbcPOJOOutputOperator.java
@@ -63,7 +63,7 @@ import com.datatorrent.lib.util.PojoUtils.GetterShort;
  * @since 2.1.0
  */
 @org.apache.hadoop.classification.InterfaceStability.Evolving
-public class JdbcPOJOOutputOperator extends AbstractJdbcTransactionableOutputOperator<Object>
+public class AbstractJdbcPOJOOutputOperator extends AbstractJdbcTransactionableOutputOperator<Object>
     implements Operator.ActivationListener<OperatorContext>
 {
   @NotNull
@@ -92,7 +92,7 @@ public class JdbcPOJOOutputOperator extends AbstractJdbcTransactionableOutputOpe
     @Override
     public void process(Object t)
     {
-      JdbcPOJOOutputOperator.super.input.process(t);
+      AbstractJdbcPOJOOutputOperator.super.input.process(t);
     }
 
   };
@@ -148,7 +148,7 @@ public class JdbcPOJOOutputOperator extends AbstractJdbcTransactionableOutputOpe
     }
   }
 
-  public JdbcPOJOOutputOperator()
+  public AbstractJdbcPOJOOutputOperator()
   {
     super();
     columnFieldGetters = Lists.newArrayList();
@@ -266,7 +266,7 @@ public class JdbcPOJOOutputOperator extends AbstractJdbcTransactionableOutputOpe
     this.tablename = tablename;
   }
 
-  private static final Logger LOG = LoggerFactory.getLogger(JdbcPOJOOutputOperator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractJdbcPOJOOutputOperator.class);
 
   @Override
   public void activate(OperatorContext context)

--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/AbstractJdbcPOJOOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/AbstractJdbcPOJOOutputOperator.java
@@ -38,7 +38,6 @@ import com.datatorrent.api.Context;
 import com.datatorrent.api.Context.OperatorContext;
 import com.datatorrent.api.DefaultInputPort;
 import com.datatorrent.api.annotation.InputPortFieldAnnotation;
-import com.datatorrent.lib.util.FieldInfo;
 import com.datatorrent.lib.util.PojoUtils;
 import com.datatorrent.lib.util.PojoUtils.Getter;
 import com.datatorrent.lib.util.PojoUtils.GetterBoolean;
@@ -61,7 +60,7 @@ import com.datatorrent.lib.util.PojoUtils.GetterShort;
 @org.apache.hadoop.classification.InterfaceStability.Evolving
 public abstract class AbstractJdbcPOJOOutputOperator extends AbstractJdbcTransactionableOutputOperator<Object>
 {
-  private List<FieldInfo> fieldInfos;
+  private List<JdbcFieldInfo> fieldInfos;
 
   protected List<Integer> columnDataTypes;
 
@@ -169,7 +168,7 @@ public abstract class AbstractJdbcPOJOOutputOperator extends AbstractJdbcTransac
   /**
    * A list of {@link FieldInfo}s where each item maps a column name to a pojo field name.
    */
-  public List<FieldInfo> getFieldInfos()
+  public List<JdbcFieldInfo> getFieldInfos()
   {
     return fieldInfos;
   }
@@ -182,7 +181,7 @@ public abstract class AbstractJdbcPOJOOutputOperator extends AbstractJdbcTransac
    * @description $[].pojoFieldExpression pojo field name or expression
    * @useSchema $[].pojoFieldExpression input.fields[].name
    */
-  public void setFieldInfos(List<FieldInfo> fieldInfos)
+  public void setFieldInfos(List<JdbcFieldInfo> fieldInfos)
   {
     this.fieldInfos = fieldInfos;
   }
@@ -195,6 +194,10 @@ public abstract class AbstractJdbcPOJOOutputOperator extends AbstractJdbcTransac
     return tablename;
   }
 
+  /**
+   * Set the target table name in database
+   * @param tablename
+   */
   public void setTablename(String tablename)
   {
     this.tablename = tablename;

--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/AbstractJdbcTransactionableOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/AbstractJdbcTransactionableOutputOperator.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 
 import com.datatorrent.api.Context;
+import com.datatorrent.api.Context.OperatorContext;
+import com.datatorrent.api.Operator;
 import com.datatorrent.lib.db.AbstractPassThruTransactionableStoreOutputOperator;
 
 /**
@@ -57,6 +59,7 @@ import com.datatorrent.lib.db.AbstractPassThruTransactionableStoreOutputOperator
  */
 public abstract class AbstractJdbcTransactionableOutputOperator<T>
     extends AbstractPassThruTransactionableStoreOutputOperator<T, JdbcTransactionalStore>
+    implements Operator.ActivationListener<Context.OperatorContext>
 {
   protected static int DEFAULT_BATCH_SIZE = 1000;
 
@@ -79,12 +82,17 @@ public abstract class AbstractJdbcTransactionableOutputOperator<T>
   public void setup(Context.OperatorContext context)
   {
     super.setup(context);
+
+  }
+
+  @Override
+  public void activate(OperatorContext context)
+  {
     try {
       updateCommand = store.connection.prepareStatement(getUpdateCommand());
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
-
   }
 
   @Override
@@ -96,6 +104,11 @@ public abstract class AbstractJdbcTransactionableOutputOperator<T>
     super.endWindow();
     tuples.clear();
     batchStartIdx = 0;
+  }
+
+  @Override
+  public void deactivate()
+  {
   }
 
   @Override

--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcFieldInfo.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcFieldInfo.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.lib.db.jdbc;
+
+import java.lang.reflect.Field;
+import java.sql.Types;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+
+import com.datatorrent.lib.util.FieldInfo;
+
+/**
+ * A {@link FieldInfo} object for Jdbc. <br/>
+ * Includes an SQL type for each field. <br/>
+ * An {@link FieldInfo} object used for JDBC output sources must have the SQL data types.
+ * This is needed to create correct getters and setters for the POJO,
+ * as well as setting the right parameter types in the JDBC prepared statement.
+ */
+public class JdbcFieldInfo extends FieldInfo
+{
+  private int sqlType;
+
+  public JdbcFieldInfo(String columnName, String pojoFieldExpression, SupportType type, String sqlTypeStr)
+  {
+    super(columnName, pojoFieldExpression, type);
+
+    sqlType = JdbcTypes.getSqlDataType(sqlTypeStr);
+  }
+
+  public int getSqlType()
+  {
+    return sqlType;
+  }
+
+  /**
+   * Set the sql data type for this {@link JdbcFieldInfo}
+   * @param sqlType
+   */
+  public void setSqlType(int sqlType)
+  {
+    this.sqlType = sqlType;
+  }
+
+  private static class JdbcTypes
+  {
+    private static Map<String, Integer> jdbcTypes;
+
+    static {
+      jdbcTypes = Maps.newHashMap();
+      for (Field f : Types.class.getFields()) {
+        try {
+          jdbcTypes.put(f.getName(), f.getInt(null));
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    public static int getSqlDataType(String sqlTypeStr)
+    {
+      if (sqlTypeStr == null || sqlTypeStr.length() == 0) {
+        return Types.NULL;
+      }
+      return jdbcTypes.get(sqlTypeStr);
+    }
+  }
+}

--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJOInsertOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJOInsertOutputOperator.java
@@ -84,20 +84,20 @@ public class JdbcPOJOInsertOutputOperator extends AbstractJdbcPOJOOutputOperator
   @Override
   public void activate(OperatorContext context)
   {
-    if(getFieldInfos() == null) {
+    if (getFieldInfos() == null) {
       Field[] fields = pojoClass.getDeclaredFields();
       // Create fieldInfos in case of direct mapping
-      List<FieldInfo> fieldInfos = Lists.newArrayList();
+      List<JdbcFieldInfo> fieldInfos = Lists.newArrayList();
       for (int i = 0; i < columnNames.size(); i++) {
         String columnName = columnNames.get(i);
         String pojoField = getMatchingField(fields, columnName);
 
-        if(columnNullabilities.get(i) == ResultSetMetaData.columnNoNulls &&
-                (pojoField == null || pojoField.length() == 0)) {
+        if (columnNullabilities.get(i) == ResultSetMetaData.columnNoNulls &&
+            (pojoField == null || pojoField.length() == 0)) {
           throw new RuntimeException("Data for a non-nullable field not found in POJO");
         } else {
-          if(pojoField != null && pojoField.length() != 0) {
-            FieldInfo fi = new FieldInfo(columnName, pojoField, null);
+          if (pojoField != null && pojoField.length() != 0) {
+            JdbcFieldInfo fi = new JdbcFieldInfo(columnName, pojoField, null, null);
             fieldInfos.add(fi);
           } else {
             columnDataTypes.remove(i);
@@ -138,7 +138,7 @@ public class JdbcPOJOInsertOutputOperator extends AbstractJdbcPOJOOutputOperator
   private String getMatchingField(Field[] fields, String columnName)
   {
     for (Field f: fields) {
-      if(f.getName().equalsIgnoreCase(columnName)) {
+      if (f.getName().equalsIgnoreCase(columnName)) {
         return f.getName();
       }
     }

--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJOInsertOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJOInsertOutputOperator.java
@@ -1,0 +1,182 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.lib.db.jdbc;
+
+import java.lang.reflect.Field;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+import com.datatorrent.api.Context.OperatorContext;
+import com.datatorrent.lib.util.FieldInfo;
+
+/**
+ * <p>
+ * JdbcPOJOInsertOutputOperator class.</p>
+ * An implementation of AbstractJdbcTransactionableOutputOperator which takes in any POJO.
+ *
+ * @displayName Jdbc Output Operator
+ * @category Output
+ * @tags database, sql, pojo, jdbc
+ * @since 2.1.0
+ */
+@org.apache.hadoop.classification.InterfaceStability.Evolving
+public class JdbcPOJOInsertOutputOperator extends AbstractJdbcPOJOOutputOperator
+{
+  String insertStatement;
+  List<String> columnNames;
+  List<Integer> columnNullabilities;
+  String columnString;
+  String valueString;
+
+  @Override
+  public void setup(OperatorContext context)
+  {
+    super.setup(context);
+
+    // Populate columnNames and columnDataTypes
+    try {
+      if (getFieldInfos() == null) { // then assume direct mapping
+        LOG.info("Assuming direct mapping between POJO fields and DB columns");
+        populateColumnDataTypes(null);
+      } else {
+        // FieldInfo supplied by user
+        StringBuilder columns = new StringBuilder();
+        StringBuilder values = new StringBuilder();
+        for (int i = 0; i < getFieldInfos().size(); i++) {
+          columns.append(getFieldInfos().get(i).getColumnName());
+          values.append("?");
+          if (i < getFieldInfos().size() - 1) {
+            columns.append(",");
+            values.append(",");
+          }
+        }
+        populateColumnDataTypes(columns.toString());
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void activate(OperatorContext context)
+  {
+    if(getFieldInfos() == null) {
+      Field[] fields = pojoClass.getDeclaredFields();
+      // Create fieldInfos in case of direct mapping
+      List<FieldInfo> fieldInfos = Lists.newArrayList();
+      for (int i = 0; i < columnNames.size(); i++) {
+        String columnName = columnNames.get(i);
+        String pojoField = getMatchingField(fields, columnName);
+
+        if(columnNullabilities.get(i) == ResultSetMetaData.columnNoNulls &&
+                (pojoField == null || pojoField.length() == 0)) {
+          throw new RuntimeException("Data for a non-nullable field not found in POJO");
+        } else {
+          if(pojoField != null && pojoField.length() != 0) {
+            FieldInfo fi = new FieldInfo(columnName, pojoField, null);
+            fieldInfos.add(fi);
+          } else {
+            columnDataTypes.remove(i);
+            columnNames.remove(i);
+            columnNullabilities.remove(i);
+            i--;
+          }
+        }
+      }
+      setFieldInfos(fieldInfos);
+    }
+
+    for (FieldInfo fi : getFieldInfos()) {
+      columnFieldGetters.add(new JdbcPOJOInputOperator.ActiveFieldInfo(fi));
+    }
+
+    StringBuilder columns = new StringBuilder();
+    StringBuilder values = new StringBuilder();
+
+    for (int i = 0; i < columnNames.size(); i++) {
+      columns.append(columnNames.get(i));
+      values.append("?");
+      if (i < columnNames.size() - 1) {
+        columns.append(",");
+        values.append(",");
+      }
+    }
+
+    insertStatement = "INSERT INTO "
+            + getTablename()
+            + " (" + columns.toString() + ")"
+            + " VALUES (" + values.toString() + ")";
+    LOG.debug("insert statement is {}", insertStatement);
+
+    super.activate(context);
+  }
+
+  private String getMatchingField(Field[] fields, String columnName)
+  {
+    for (Field f: fields) {
+      if(f.getName().equalsIgnoreCase(columnName)) {
+        return f.getName();
+      }
+    }
+    return null;
+  }
+
+  protected void populateColumnDataTypes(String columns) throws SQLException
+  {
+    columnNames = Lists.newArrayList();
+    columnDataTypes = Lists.newArrayList();
+    columnNullabilities = Lists.newArrayList();
+
+    try (Statement st = store.getConnection().createStatement()) {
+      if (columns == null || columns.length() == 0) {
+        columns = "*";
+      }
+      ResultSet rs = st.executeQuery("select " + columns + " from " + getTablename());
+
+      ResultSetMetaData rsMetaData = rs.getMetaData();
+      LOG.debug("resultSet MetaData column count {}", rsMetaData.getColumnCount());
+
+      for (int i = 1; i <= rsMetaData.getColumnCount(); i++) {
+        int type = rsMetaData.getColumnType(i);
+        String columnName = rsMetaData.getColumnName(i);
+        columnNames.add(columnName);
+        columnDataTypes.add(type);
+        columnNullabilities.add(rsMetaData.isNullable(i));
+        LOG.debug("column name {} type {}", rsMetaData.getColumnName(i), type);
+      }
+    }
+  }
+
+
+  @Override
+  protected String getUpdateCommand()
+  {
+    return insertStatement;
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcPOJOInsertOutputOperator.class);
+}

--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJOInsertOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJOInsertOutputOperator.java
@@ -60,7 +60,7 @@ public class JdbcPOJOInsertOutputOperator extends AbstractJdbcPOJOOutputOperator
     // Populate columnNames and columnDataTypes
     try {
       if (getFieldInfos() == null) { // then assume direct mapping
-        LOG.info("Assuming direct mapping between POJO fields and DB columns");
+        LOG.info("FieldInfo missing. Assuming direct mapping between POJO fields and DB columns");
         populateColumnDataTypes(null);
       } else {
         // FieldInfo supplied by user
@@ -94,7 +94,7 @@ public class JdbcPOJOInsertOutputOperator extends AbstractJdbcPOJOOutputOperator
 
         if (columnNullabilities.get(i) == ResultSetMetaData.columnNoNulls &&
             (pojoField == null || pojoField.length() == 0)) {
-          throw new RuntimeException("Data for a non-nullable field not found in POJO");
+          throw new RuntimeException("Data for a non-nullable field: " + columnName + " not found in POJO");
         } else {
           if (pojoField != null && pojoField.length() != 0) {
             JdbcFieldInfo fi = new JdbcFieldInfo(columnName, pojoField, null, null);

--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJONonInsertOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJONonInsertOutputOperator.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.lib.db.jdbc;
+
+import javax.validation.constraints.NotNull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+import com.datatorrent.api.Context.OperatorContext;
+
+/**
+ * <p>
+ * JdbcPOJOInsertOutputOperator class.</p>
+ * An implementation of AbstractJdbcTransactionableOutputOperator which takes in any POJO.
+ *
+ * @displayName Jdbc Output Operator
+ * @category Output
+ * @tags database, sql, pojo, jdbc
+ * @since 2.1.0
+ */
+@org.apache.hadoop.classification.InterfaceStability.Evolving
+public class JdbcPOJONonInsertOutputOperator extends AbstractJdbcPOJOOutputOperator
+{
+  @NotNull
+  String sqlStatement;
+
+  @Override
+  public void setup(OperatorContext context)
+  {
+    super.setup(context);
+
+    columnDataTypes = Lists.newArrayList();
+    for (JdbcFieldInfo fi : getFieldInfos()) {
+      columnFieldGetters.add(new JdbcPOJOInputOperator.ActiveFieldInfo(fi));
+      columnDataTypes.add(fi.getSqlType());
+    }
+  }
+
+  @Override
+  protected String getUpdateCommand()
+  {
+    return sqlStatement;
+  }
+
+  /**
+   * Sets the parameterized SQL query for the JDBC update operation.
+   * This can be an update, delete or a merge query.
+   * Example: "update testTable set id = ? where name = ?"
+   * @param sqlStatement the SQL query
+   */
+  public void setSqlStatement(String sqlStatement)
+  {
+    this.sqlStatement = sqlStatement;
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcPOJONonInsertOutputOperator.class);
+}

--- a/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcOperatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcOperatorTest.java
@@ -202,7 +202,7 @@ public class JdbcOperatorTest
     }
   }
 
-  private static class TestPOJOOutputOperator extends JdbcPOJOOutputOperator
+  private static class TestPOJOOutputOperator extends AbstractJdbcPOJOOutputOperator
   {
     TestPOJOOutputOperator()
     {

--- a/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcOperatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcOperatorTest.java
@@ -53,6 +53,8 @@ public class JdbcOperatorTest
 
   private static final String TABLE_NAME = "test_event_table";
   private static final String TABLE_POJO_NAME = "test_pojo_event_table";
+  private static final String TABLE_POJO_NAME_ID_DIFF = "test_pojo_event_table_id_diff";
+  private static final String TABLE_POJO_NAME_NAME_DIFF = "test_pojo_event_table_name_diff";
   private static String APP_ID = "JdbcOperatorTest";
   private static int OPERATOR_ID = 0;
 
@@ -126,6 +128,12 @@ public class JdbcOperatorTest
       String createPOJOTable = "CREATE TABLE IF NOT EXISTS " + TABLE_POJO_NAME
           + "(id INTEGER not NULL,name VARCHAR(255), PRIMARY KEY ( id ))";
       stmt.executeUpdate(createPOJOTable);
+      String createPOJOTableIdDiff = "CREATE TABLE IF NOT EXISTS " + TABLE_POJO_NAME_ID_DIFF
+              + "(id1 INTEGER not NULL,name VARCHAR(255), PRIMARY KEY ( id1 ))";
+      stmt.executeUpdate(createPOJOTableIdDiff);
+      String createPOJOTableNameDiff = "CREATE TABLE IF NOT EXISTS " + TABLE_POJO_NAME_NAME_DIFF
+              + "(id INTEGER not NULL,name1 VARCHAR(255), PRIMARY KEY ( id ))";
+      stmt.executeUpdate(createPOJOTableNameDiff);
     } catch (Throwable e) {
       DTThrowable.rethrow(e);
     }
@@ -138,6 +146,9 @@ public class JdbcOperatorTest
       Statement stmt = con.createStatement();
 
       String cleanTable = "delete from " + TABLE_NAME;
+      stmt.executeUpdate(cleanTable);
+
+      cleanTable = "delete from " + TABLE_POJO_NAME;
       stmt.executeUpdate(cleanTable);
 
       cleanTable = "delete from " + JdbcTransactionalStore.DEFAULT_META_TABLE;
@@ -202,21 +213,37 @@ public class JdbcOperatorTest
     }
   }
 
-  private static class TestPOJOOutputOperator extends AbstractJdbcPOJOOutputOperator
+  private static class TestPOJOOutputOperator extends JdbcPOJOInsertOutputOperator
   {
     TestPOJOOutputOperator()
     {
       cleanTable();
     }
 
-    public int getNumOfEventsInStore()
+    public int getNumOfEventsInStore(String tableName)
     {
       Connection con;
       try {
         con = DriverManager.getConnection(URL);
         Statement stmt = con.createStatement();
 
-        String countQuery = "SELECT count(*) from " + TABLE_POJO_NAME;
+        String countQuery = "SELECT count(*) from " + tableName;
+        ResultSet resultSet = stmt.executeQuery(countQuery);
+        resultSet.next();
+        return resultSet.getInt(1);
+      } catch (SQLException e) {
+        throw new RuntimeException("fetching count", e);
+      }
+    }
+
+    public int getNumOfNullEventsInStore(String tableName)
+    {
+      Connection con;
+      try {
+        con = DriverManager.getConnection(URL);
+        Statement stmt = con.createStatement();
+
+        String countQuery = "SELECT count(*) from " + tableName + " where name1 is null";
         ResultSet resultSet = stmt.executeQuery(countQuery);
         resultSet.next();
         return resultSet.getInt(1);
@@ -273,6 +300,7 @@ public class JdbcOperatorTest
 
     outputOperator.setup(context);
 
+    outputOperator.activate(context);
     List<TestEvent> events = Lists.newArrayList();
     for (int i = 0; i < 10; i++) {
       events.add(new TestEvent(i));
@@ -332,7 +360,98 @@ public class JdbcOperatorTest
     }
     outputOperator.endWindow();
 
-    Assert.assertEquals("rows in db", 10, outputOperator.getNumOfEventsInStore());
+    Assert.assertEquals("rows in db", 10, outputOperator.getNumOfEventsInStore(TABLE_POJO_NAME));
+  }
+
+  /**
+   * This test will assume direct mapping for POJO fields to DB columns
+   */
+  @Test
+  public void testJdbcPojoInsertOutputOperator()
+  {
+    JdbcTransactionalStore transactionalStore = new JdbcTransactionalStore();
+    transactionalStore.setDatabaseDriver(DB_DRIVER);
+    transactionalStore.setDatabaseUrl(URL);
+
+    com.datatorrent.api.Attribute.AttributeMap.DefaultAttributeMap attributeMap =
+        new com.datatorrent.api.Attribute.AttributeMap.DefaultAttributeMap();
+    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
+    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(
+        OPERATOR_ID, attributeMap);
+
+    TestPOJOOutputOperator outputOperator = new TestPOJOOutputOperator();
+    outputOperator.setBatchSize(3);
+    outputOperator.setTablename(TABLE_POJO_NAME);
+
+    outputOperator.setStore(transactionalStore);
+
+    outputOperator.setup(context);
+
+    Attribute.AttributeMap.DefaultAttributeMap portAttributes = new Attribute.AttributeMap.DefaultAttributeMap();
+    portAttributes.put(Context.PortContext.TUPLE_CLASS, TestPOJOEvent.class);
+    TestPortContext tpc = new TestPortContext(portAttributes);
+    outputOperator.input.setup(tpc);
+
+    outputOperator.activate(context);
+
+    List<TestPOJOEvent> events = Lists.newArrayList();
+    for (int i = 0; i < 10; i++) {
+      events.add(new TestPOJOEvent(i, "test" + i));
+    }
+
+    outputOperator.beginWindow(0);
+    for (TestPOJOEvent event : events) {
+      outputOperator.input.process(event);
+    }
+    outputOperator.endWindow();
+
+    Assert.assertEquals("rows in db", 10, outputOperator.getNumOfEventsInStore(TABLE_POJO_NAME));
+  }
+
+  /**
+   * This test will assume direct mapping for POJO fields to DB columns
+   */
+  @Test
+  public void testJdbcPojoInsertOutputOperatorNullName()
+  {
+    JdbcTransactionalStore transactionalStore = new JdbcTransactionalStore();
+    transactionalStore.setDatabaseDriver(DB_DRIVER);
+    transactionalStore.setDatabaseUrl(URL);
+
+    com.datatorrent.api.Attribute.AttributeMap.DefaultAttributeMap attributeMap =
+        new com.datatorrent.api.Attribute.AttributeMap.DefaultAttributeMap();
+    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
+    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(
+        OPERATOR_ID, attributeMap);
+
+    TestPOJOOutputOperator outputOperator = new TestPOJOOutputOperator();
+    outputOperator.setBatchSize(3);
+    outputOperator.setTablename(TABLE_POJO_NAME_NAME_DIFF);
+
+    outputOperator.setStore(transactionalStore);
+
+    outputOperator.setup(context);
+
+    Attribute.AttributeMap.DefaultAttributeMap portAttributes = new Attribute.AttributeMap.DefaultAttributeMap();
+    portAttributes.put(Context.PortContext.TUPLE_CLASS, TestPOJOEvent.class);
+    TestPortContext tpc = new TestPortContext(portAttributes);
+    outputOperator.input.setup(tpc);
+
+    outputOperator.activate(context);
+
+    List<TestPOJOEvent> events = Lists.newArrayList();
+    for (int i = 0; i < 10; i++) {
+      events.add(new TestPOJOEvent(i, "test" + i));
+    }
+
+    outputOperator.beginWindow(0);
+    for (TestPOJOEvent event : events) {
+      outputOperator.input.process(event);
+    }
+    outputOperator.endWindow();
+
+    Assert.assertEquals("rows in db", 10, outputOperator.getNumOfEventsInStore(TABLE_POJO_NAME_NAME_DIFF));
+    Assert.assertEquals("null name rows in db", 10, outputOperator.getNumOfNullEventsInStore(TABLE_POJO_NAME_NAME_DIFF));
   }
 
   @Test


### PR DESCRIPTION
1. Renaming JdbcPOJOOutputOperator to AbstractJdbcPOJOOutputOperator.
2. Added JdbcPOJOInsertOutputOperator for insert queries. Added support for automatic mapping of fields from POJO to DB columns. 
3. Added JdbcPOJONonInsertOutputOperator for update / delete / merge queries. Refactored accordingly. 
   Added unit tests.
