### PR TITLE
APEXMALHAR-1966: Update casandra output opreator

### DIFF
--- a/contrib/src/main/java/com/datatorrent/contrib/cassandra/AbstractCassandraTransactionableOutputOperatorPS.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/cassandra/AbstractCassandraTransactionableOutputOperatorPS.java
@@ -22,6 +22,8 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.DriverException;
 import com.datatorrent.api.Context;
+import com.datatorrent.api.Operator;
+import com.datatorrent.api.Context.OperatorContext;
 
 import javax.annotation.Nonnull;
 
@@ -49,7 +51,8 @@ import javax.annotation.Nonnull;
  * @param <T>type of tuple</T>
  * @since 1.0.2
  */
-public abstract class AbstractCassandraTransactionableOutputOperatorPS<T> extends AbstractCassandraTransactionableOutputOperator<T>{
+public abstract class AbstractCassandraTransactionableOutputOperatorPS<T> extends AbstractCassandraTransactionableOutputOperator<T> implements Operator.ActivationListener<Context.OperatorContext>
+{
 
   private transient PreparedStatement updateCommand;
 
@@ -65,7 +68,13 @@ public abstract class AbstractCassandraTransactionableOutputOperatorPS<T> extend
   public void setup(Context.OperatorContext context)
   {
     super.setup(context);
+  }
+
+  @Override
+  public void activate(OperatorContext context)
+  {
     updateCommand = getUpdateCommand();
+
   }
 
   /**

--- a/contrib/src/test/java/com/datatorrent/contrib/cassandra/CassandraOperatorTest.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/cassandra/CassandraOperatorTest.java
@@ -33,7 +33,9 @@ import com.google.common.collect.Lists;
 
 import java.util.*;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.AfterClass;
@@ -54,6 +56,8 @@ public class CassandraOperatorTest
   private static final int OPERATOR_ID = 0;
   private static Cluster cluster = null;
   private static Session session = null;
+  private OperatorContextTestHelper.TestIdOperatorContext context;
+  private TestPortContext tpc;
 
   @SuppressWarnings("unused")
   private static class TestEvent
@@ -105,6 +109,25 @@ public class CassandraOperatorTest
     if (cluster != null) {
       cluster.close();
     }
+  }
+
+  @Before
+  public void setupForTest()
+  {
+    AttributeMap.DefaultAttributeMap attributeMap = new AttributeMap.DefaultAttributeMap();
+    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
+    context = new OperatorContextTestHelper.TestIdOperatorContext(OPERATOR_ID, attributeMap);
+
+    Attribute.AttributeMap.DefaultAttributeMap portAttributes = new Attribute.AttributeMap.DefaultAttributeMap();
+    portAttributes.put(Context.PortContext.TUPLE_CLASS, TestPojo.class);
+    tpc = new TestPortContext(portAttributes);
+  }
+
+  @After
+  public void afterTest()
+  {
+    session.execute("TRUNCATE " + CassandraTransactionalStore.DEFAULT_META_TABLE);
+    session.execute("TRUNCATE " + KEYSPACE + "." + TABLE_NAME);
   }
 
   private static class TestOutputOperator extends CassandraPOJOOutputOperator
@@ -220,23 +243,9 @@ public class CassandraOperatorTest
   @Test
   public void testCassandraProtocolVersion()
   {
-    CassandraTransactionalStore transactionalStore = new CassandraTransactionalStore();
-    transactionalStore.setNode(NODE);
-    transactionalStore.setKeyspace(KEYSPACE);
-    transactionalStore.setProtocolVersion("v2");
+    TestOutputOperator outputOperator = setupForOutputOperatorTest();
+    outputOperator.getStore().setProtocolVersion("v2");
 
-    AttributeMap.DefaultAttributeMap attributeMap = new AttributeMap.DefaultAttributeMap();
-    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
-    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(OPERATOR_ID, attributeMap);
-
-    TestOutputOperator outputOperator = new TestOutputOperator();
-
-    outputOperator.setTablename(TABLE_NAME);
-    List<FieldInfo> fieldInfos = Lists.newArrayList();
-    fieldInfos.add(new FieldInfo("id", "id", null));
-
-    outputOperator.setStore(transactionalStore);
-    outputOperator.setFieldInfos(fieldInfos);
     outputOperator.setup(context);
 
     Configuration config = outputOperator.getStore().getCluster().getConfiguration();
@@ -246,17 +255,8 @@ public class CassandraOperatorTest
   @Test
   public void testCassandraOutputOperator()
   {
-    CassandraTransactionalStore transactionalStore = new CassandraTransactionalStore();
-    transactionalStore.setNode(NODE);
-    transactionalStore.setKeyspace(KEYSPACE);
+    TestOutputOperator outputOperator = setupForOutputOperatorTest();
 
-    AttributeMap.DefaultAttributeMap attributeMap = new AttributeMap.DefaultAttributeMap();
-    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
-    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(OPERATOR_ID, attributeMap);
-
-    TestOutputOperator outputOperator = new TestOutputOperator();
-
-    outputOperator.setTablename(TABLE_NAME);
     List<FieldInfo> fieldInfos = Lists.newArrayList();
     fieldInfos.add(new FieldInfo("id", "id", null));
     fieldInfos.add(new FieldInfo("age", "age", null));
@@ -269,15 +269,9 @@ public class CassandraOperatorTest
     fieldInfos.add(new FieldInfo("set1", "set1", null));
     fieldInfos.add(new FieldInfo("test", "test", null));
 
-    outputOperator.setStore(transactionalStore);
     outputOperator.setFieldInfos(fieldInfos);
-    outputOperator.setup(context);
-
-    Attribute.AttributeMap.DefaultAttributeMap portAttributes = new Attribute.AttributeMap.DefaultAttributeMap();
-    portAttributes.put(Context.PortContext.TUPLE_CLASS, TestPojo.class);
-    TestPortContext tpc = new TestPortContext(portAttributes);
-
     outputOperator.input.setup(tpc);
+    outputOperator.setup(context);
     outputOperator.activate(context);
 
     List<TestPojo> events = Lists.newArrayList();
@@ -299,6 +293,88 @@ public class CassandraOperatorTest
 
     Assert.assertEquals("rows in db", 3, outputOperator.getNumOfEventsInStore());
     outputOperator.getEventsInStore();
+  }
+
+  @Test
+  public void testPopulateFieldInfo()
+  {
+    TestOutputOperator outputOperator = setupForOutputOperatorTest();
+    outputOperator.input.setup(tpc);
+    outputOperator.setup(context);
+    outputOperator.activate(context);
+
+    List<TestPojo> events = Lists.newArrayList();
+    for (int i = 0; i < 3; i++) {
+      Set<Integer> set = new HashSet<Integer>();
+      set.add(i);
+      List<Integer> list = new ArrayList<Integer>();
+      list.add(i);
+      Map<String, Integer> map = new HashMap<String, Integer>();
+      map.put("key" + i, i);
+      events.add(new TestPojo(UUID.randomUUID(), i, "abclast", true, i, 2.0, set, list, map, new Date(System.currentTimeMillis())));
+    }
+
+    outputOperator.beginWindow(0);
+    for (TestPojo event : events) {
+      outputOperator.input.process(event);
+    }
+    outputOperator.endWindow();
+
+    Assert.assertEquals("rows in db", 3, outputOperator.getNumOfEventsInStore());
+    outputOperator.getEventsInStore();
+  }
+
+  @Test
+  public void testupdateQueryWithParameters()
+  {
+    TestOutputOperator outputOperator = setupForOutputOperatorTest();
+    outputOperator.input.setup(tpc);
+    outputOperator.setup(context);
+    outputOperator.activate(context);
+
+    UUID id = UUID.randomUUID();
+    TestPojo testPojo = new TestPojo(id, 20, "Laura", true, 10, 2.0, new HashSet<Integer>(), new ArrayList<Integer>(), null, new Date(System.currentTimeMillis()));
+    // insert record
+    outputOperator.beginWindow(0);
+    outputOperator.input.process(testPojo);
+    outputOperator.endWindow();
+    Assert.assertEquals("rows in db", 1, outputOperator.getNumOfEventsInStore());
+
+    // update record
+    String updateLastName = "Laurel";
+    String updateQuery = "update " + KEYSPACE + "." + TABLE_NAME + " set lastname='" + updateLastName + "' where id=?";
+    // set specific files required by update command in order as per query
+    List<FieldInfo> fieldInfos = Lists.newArrayList();
+    fieldInfos.add(new FieldInfo("id", "id", null));
+
+    // reset the operator to run new query
+    outputOperator.setQuery(updateQuery);
+    outputOperator.setFieldInfos(fieldInfos);
+    outputOperator.setup(context);
+    outputOperator.activate(context);
+
+    outputOperator.beginWindow(1);
+    outputOperator.input.process(testPojo);
+    outputOperator.endWindow();
+
+    String recordsQuery = "SELECT * from " + TABLE_NAME + ";";
+    ResultSet resultSetRecords = session.execute(recordsQuery);
+    for (Row row : resultSetRecords) {
+      Assert.assertEquals("Updated last name", updateLastName, row.getString("lastname"));
+    }
+  }
+
+  private TestOutputOperator setupForOutputOperatorTest()
+  {
+    CassandraTransactionalStore transactionalStore = new CassandraTransactionalStore();
+    transactionalStore.setNode(NODE);
+    transactionalStore.setKeyspace(KEYSPACE);
+
+    TestOutputOperator operator = new TestOutputOperator();
+    operator = new TestOutputOperator();
+    operator.setTablename(TABLE_NAME);
+    operator.setStore(transactionalStore);
+    return operator;
   }
 
   /*

--- a/library/src/main/java/com/datatorrent/lib/db/AbstractTransactionableStoreOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/AbstractTransactionableStoreOutputOperator.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import com.datatorrent.api.Context.OperatorContext;
 import com.datatorrent.api.DAG;
 import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
 import com.datatorrent.api.annotation.InputPortFieldAnnotation;
 import com.datatorrent.common.util.BaseOperator;
 
@@ -66,6 +67,8 @@ public abstract class AbstractTransactionableStoreOutputOperator<T, S extends Tr
     }
 
   };
+
+  public final transient DefaultOutputPort<T> error = new DefaultOutputPort<>();
 
   /**
    * Gets the store


### PR DESCRIPTION
Changes:
1. Accept user queries (can be insert/update/delete)
2. Use default field info, as per pojo fields if fieldInfos is not set.
3. Add metrics.
