### PR TITLE
APEXMALHAR-2077 AbstractSingleFileOutputOperator appending partitionID

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/io/fs/AbstractSingleFileOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/AbstractSingleFileOutputOperator.java
@@ -20,6 +20,10 @@ package com.datatorrent.lib.io.fs;
 
 import javax.validation.constraints.NotNull;
 
+import org.apache.commons.lang.StringUtils;
+
+import com.datatorrent.api.Context.OperatorContext;
+
 /**
  * This is a simple class that output all tuples to a single file.
  *
@@ -39,10 +43,41 @@ public abstract class AbstractSingleFileOutputOperator<INPUT> extends AbstractFi
   @NotNull
   protected String outputFileName;
 
+  /**
+   * partitionedFileName string format specifier 
+      e.g. fileName_physicalPartionId -> %s_%d 
+   */
+  private String partitionedFileNameformat = "%s_%d";
+
+  /**
+   * Derived name for file based on physicalPartitionId
+   */
+  private transient String partitionedFileName;
+
+  /**
+   * Physical partition id for the current partition.
+   */
+  private transient int physicalPartitionId;
+
+  /**
+   * Initializing current partition id, partitionedFileName etc. {@inheritDoc}
+   */
+  @Override
+  public void setup(OperatorContext context)
+  {
+    super.setup(context);
+    physicalPartitionId = context.getId();
+    if (StringUtils.isEmpty(partitionedFileNameformat)) {
+      partitionedFileName = outputFileName;
+    } else {
+      partitionedFileName = String.format(partitionedFileNameformat, outputFileName, physicalPartitionId);
+    }
+  }
+
   @Override
   protected String getFileName(INPUT tuple)
   {
-    return outputFileName;
+    return partitionedFileName;
   }
 
   /**
@@ -62,4 +97,32 @@ public abstract class AbstractSingleFileOutputOperator<INPUT> extends AbstractFi
   {
     return outputFileName;
   }
+
+  /**
+   * @return string format specifier for the partitioned file name
+   */
+  public String getPartitionedFileNameformat()
+  {
+    return partitionedFileNameformat;
+  }
+  
+  /**
+   * @param partitionedFileNameformat
+   *          string format specifier for the partitioned file name. It should have one %s and one %d.
+   *          e.g. fileName_physicalPartionId -> %s_%d 
+   */
+  public void setPartitionedFileNameformat(String partitionedFileNameformat)
+  {
+    this.partitionedFileNameformat = partitionedFileNameformat;
+  }
+  
+  /**
+   * @return
+   * Derived name for file based on physicalPartitionId
+   */
+  public String getPartitionedFileName()
+  {
+    return partitionedFileName;
+  }
+  
 }

--- a/library/src/test/java/com/datatorrent/lib/io/fs/AbstractSingleFileOutputOperatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/io/fs/AbstractSingleFileOutputOperatorTest.java
@@ -144,6 +144,7 @@ public class AbstractSingleFileOutputOperatorTest
   public void testSingleFileCompletedWrite()
   {
     writer.setOutputFileName(SINGLE_FILE);
+    writer.setPartitionedFileNameformat(null);
 
     writer.setFilePath(testMeta.getDir());
 
@@ -177,7 +178,8 @@ public class AbstractSingleFileOutputOperatorTest
   public void testSingleFileFailedWrite()
   {
     writer.setOutputFileName(SINGLE_FILE);
-
+    writer.setPartitionedFileNameformat("");
+    
     File meta = new File(testMeta.getDir());
     writer.setFilePath(meta.getAbsolutePath());
 

--- a/library/src/test/java/org/apache/apex/malhar/lib/fs/BytesFileOutputOperatorTest.java
+++ b/library/src/test/java/org/apache/apex/malhar/lib/fs/BytesFileOutputOperatorTest.java
@@ -31,7 +31,7 @@ import org.apache.commons.io.FileUtils;
 import com.datatorrent.lib.io.fs.AbstractFileOutputOperatorTest;
 import com.datatorrent.netlet.util.DTThrowable;
 
-public class HDFSOutputOperatorTest extends AbstractFileOutputOperatorTest
+public class BytesFileOutputOperatorTest extends AbstractFileOutputOperatorTest
 {
 
   /**
@@ -42,8 +42,8 @@ public class HDFSOutputOperatorTest extends AbstractFileOutputOperatorTest
   @Test
   public void testIdleWindowsFinalize() throws IOException
   {
-    HDFSOutputOperator writer = new HDFSOutputOperator();
-    writer.setFileName("output.txt");
+    BytesFileOutputOperator writer = new BytesFileOutputOperator();
+    writer.setOutputFileName("output.txt");
     writer.setFilePath(testMeta.getDir());
     writer.setAlwaysWriteToTmp(true);
     writer.setMaxIdleWindows(5);
@@ -88,8 +88,8 @@ public class HDFSOutputOperatorTest extends AbstractFileOutputOperatorTest
   @Test
   public void testTupleCountFinalize() throws IOException
   {
-    HDFSOutputOperator writer = new HDFSOutputOperator();
-    writer.setFileName("output.txt");
+    BytesFileOutputOperator writer = new BytesFileOutputOperator();
+    writer.setOutputFileName("output.txt");
     writer.setFilePath(testMeta.getDir());
     writer.setAlwaysWriteToTmp(true);
     writer.setMaxTupleCount(10);


### PR DESCRIPTION
1. Renamed HDFSOutputOperator to BytesFileOutputOperator
2. Moved partitionID related logic into AbstractSingleFileOutputOperator
3. BytesFileOutputOperator extends AbstractSingleFileOutputOperator
4. renamed currentPartName to partitionedFileName
5. update partitionedFileName from field setters
