### PR TITLE
[APEXMALHAR-175] KeyValPair isn't automatically sticky partitioned for key

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/util/KeyValPair.java
+++ b/library/src/main/java/com/datatorrent/lib/util/KeyValPair.java
@@ -53,4 +53,9 @@ public class KeyValPair<K, V> extends AbstractMap.SimpleEntry<K, V>
     super(k, v);
   }
 
+  @Override
+  public int hashCode()
+  {
+    return getKey().hashCode();
+  }
 }


### PR DESCRIPTION
- Updated KeyValPair to override hashCode to support sticky partitioning by key.
