### PR TITLE
APEXMALHAR-2122 Upgrading elasticsearch java api from 1.1.2 to 2.3.3.

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -274,7 +274,7 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>1.1.2</version>
+      <version>2.3.3</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/contrib/src/main/java/com/datatorrent/contrib/elasticsearch/AbstractElasticSearchInputOperator.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/elasticsearch/AbstractElasticSearchInputOperator.java
@@ -59,7 +59,7 @@ public abstract class AbstractElasticSearchInputOperator<T, S extends ElasticSea
   public void setup(OperatorContext t1)
   {
     super.setup(t1);
-    this.searchRequestBuilder = new SearchRequestBuilder(store.client);
+    this.searchRequestBuilder = store.client.prepareSearch(getIndexName());
   }
 
   /**
@@ -95,5 +95,17 @@ public abstract class AbstractElasticSearchInputOperator<T, S extends ElasticSea
    * @return {@link SearchRequestBuilder}
    */
   protected abstract SearchRequestBuilder getSearchRequestBuilder();
+
+  /**
+   *
+   * @return
+   */
+  protected abstract String getIndexName();
+
+  /**
+   *
+   * @param indexName
+   */
+  protected abstract void setIndexName(String indexName);
 
 }

--- a/contrib/src/main/java/com/datatorrent/contrib/elasticsearch/ElasticSearchConnectable.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/elasticsearch/ElasticSearchConnectable.java
@@ -19,10 +19,12 @@
 package com.datatorrent.contrib.elasticsearch;
 
 import java.io.IOException;
+import java.net.InetAddress;
 
 import javax.validation.constraints.NotNull;
 
 import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 
 import com.datatorrent.lib.db.Connectable;
@@ -51,6 +53,9 @@ public class ElasticSearchConnectable implements Connectable
   protected String hostName;
   @NotNull
   protected int port;
+
+  @NotNull
+  protected String clusterName;
 
   protected transient TransportClient client;
 
@@ -88,16 +93,35 @@ public class ElasticSearchConnectable implements Connectable
     this.port = port;
   }
 
+  /**
+   *
+   * @return
+   */
+  public String getClusterName()
+  {
+    return clusterName;
+  }
+
+  /**
+   *
+   * @param clusterName
+   */
+  public void setClusterName(String clusterName)
+  {
+    this.clusterName = clusterName;
+  }
+
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see com.datatorrent.lib.db.Connectable#connect()
    */
   @Override
   public void connect() throws IOException
   {
-    client = new TransportClient();
-    client.addTransportAddress(new InetSocketTransportAddress(hostName, port));
+    Settings settings = Settings.settingsBuilder().put("cluster.name", clusterName).put("client.transport.sniff", true).build();
+    client = TransportClient.builder().settings(settings).build();
+    client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName(hostName),port));
   }
 
   /*

--- a/contrib/src/main/java/org/apache/apex/malhar/contrib/parser/StreamingJsonParser.java
+++ b/contrib/src/main/java/org/apache/apex/malhar/contrib/parser/StreamingJsonParser.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.StringTokenizer;
 
-import org.elasticsearch.common.primitives.Ints;
+import com.google.common.primitives.Ints;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;

--- a/contrib/src/test/java/com/datatorrent/contrib/elasticsearch/ElasticSearchOperatorTest.java
+++ b/contrib/src/test/java/com/datatorrent/contrib/elasticsearch/ElasticSearchOperatorTest.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.client.transport.NoNodeAvailableException;
-import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,6 +51,7 @@ public class ElasticSearchOperatorTest
     ElasticSearchConnectable store = new ElasticSearchConnectable();
     store.setHostName("localhost");
     store.setPort(9300);
+    store.setClusterName("elasticsearch");
     return store;
   }
 
@@ -89,7 +90,7 @@ public class ElasticSearchOperatorTest
     ElasticSearchMapOutputOperator<Map<String, Object>> operator = new ElasticSearchMapOutputOperator<Map<String, Object>>() {
       /*
        * (non-Javadoc)
-       * 
+       *
        * @see com.datatorrent.contrib.elasticsearch. AbstractElasticSearchOutputOperator #processTuple(java.lang.Object)
        */
       @Override
@@ -128,8 +129,7 @@ public class ElasticSearchOperatorTest
 
   /**
    * Read data written to elastic search
-   * 
-   * @param tupleIDs
+   *
    * @param testStartTime
    */
   private List<String> readFromES(List<String> writtenTupleIDs, final long testStartTime)
@@ -137,14 +137,14 @@ public class ElasticSearchOperatorTest
     ElasticSearchMapInputOperator<Map<String, Object>> operator = new ElasticSearchMapInputOperator<Map<String, Object>>() {
       /**
        * Set SearchRequestBuilder parameters specific to current window.
-       * 
+       *
        * @see com.datatorrent.contrib.elasticsearch.ElasticSearchMapInputOperator#getSearchRequestBuilder()
        */
       @Override
       protected SearchRequestBuilder getSearchRequestBuilder()
       {
         long time = System.currentTimeMillis();
-        return searchRequestBuilder.setPostFilter(FilterBuilders.rangeFilter(POST_DATE).from(testStartTime).to(time)) // Filter
+        return searchRequestBuilder.setPostFilter(QueryBuilders.rangeQuery(POST_DATE).from(testStartTime).to(time)) // Filter
             .setSize(15).setExplain(false);
       }
     };


### PR DESCRIPTION
Upgrading elasticsearch java api from 1.1.2 to 2.3.3. Made necessary changes in operator. Fixed build issues recognised while migration.

@gauravgopi123 you can close [old PR](https://github.com/apache/apex-malhar/pull/325), this is created with jira issue id as branch name.
