### PR TITLE
APEXMALHAR-2206 : Application tests fixes

### DIFF
--- a/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcIOAppTest.java
+++ b/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcIOAppTest.java
@@ -121,13 +121,10 @@ public class JdbcIOAppTest
       lma.prepareDAG(new JdbcIOApp(), conf);
       LocalMode.Controller lc = lma.getController();
       lc.runAsync();
-
       // wait for records to be added to table    
       Thread.sleep(3000);
-
-      Assert.assertEquals("Events in store", 10, getNumOfEventsInStore());
       lc.shutdown();
-
+      Assert.assertEquals("Events in store", 10, getNumOfEventsInStore());
     } catch (ConstraintViolationException e) {
       Assert.fail("constraint violations: " + e.getConstraintViolations());
     }

--- a/library/src/test/java/com/datatorrent/lib/formatter/JsonFormatterTest.java
+++ b/library/src/test/java/com/datatorrent/lib/formatter/JsonFormatterTest.java
@@ -218,7 +218,7 @@ public class JsonFormatterTest
       JsonFormatter formatter = dag.addOperator("formatter", new JsonFormatter());
       dag.getMeta(formatter).getMeta(formatter.in).getAttributes().put(Context.PortContext.TUPLE_CLASS, Ad.class);
       ConsoleOutputOperator output = dag.addOperator("output", new ConsoleOutputOperator());
-      output.setDebug(true);
+      output.setDebug(false);
       dag.addStream("input", input.output, formatter.in);
       dag.addStream("output", formatter.out, output.input);
     }

--- a/library/src/test/java/org/apache/apex/malhar/lib/dedup/DeduperPartitioningTest.java
+++ b/library/src/test/java/org/apache/apex/malhar/lib/dedup/DeduperPartitioningTest.java
@@ -190,7 +190,7 @@ public class DeduperPartitioningTest
     LocalMode.Controller lc = lma.getController();
     lc.runAsync();
     app.dedup.latch.await();
-    Assert.assertFalse(testFailed);
     lc.shutdown();
+    Assert.assertFalse(testFailed);
   }
 }

--- a/library/src/test/java/org/apache/apex/malhar/lib/join/POJOPartitionJoinOperatorTest.java
+++ b/library/src/test/java/org/apache/apex/malhar/lib/join/POJOPartitionJoinOperatorTest.java
@@ -188,8 +188,8 @@ public class POJOPartitionJoinOperatorTest
     LocalMode.Controller lc = lma.getController();
     lc.runAsync();
     app.joinOp.latch.await();
-    Assert.assertFalse(testFailed);
     lc.shutdown();
+    Assert.assertFalse(testFailed);
   }
 
 }


### PR DESCRIPTION
1. Fixing placement for lc.shutdown()
2. Disabling log messages for console output in JsonFormatterTest.
