### PR TITLE
APEXMALHAR-2250: Ignore directories while scanning.

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/io/fs/AbstractFileInputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/AbstractFileInputOperator.java
@@ -1039,7 +1039,7 @@ public abstract class AbstractFileInputOperator<T>
             continue;
           }
 
-          if (acceptFile(filePathStr)) {
+          if (acceptFile(status)) {
             LOG.debug("Found {}", filePathStr);
             pathSet.add(path);
           } else {
@@ -1058,6 +1058,14 @@ public abstract class AbstractFileInputOperator<T>
     protected int getPartition(String filePathStr)
     {
       return filePathStr.hashCode();
+    }
+
+    protected boolean acceptFile(FileStatus fstatus)
+    {
+      if (fstatus.isDirectory()) {
+        return false;
+      }
+      return acceptFile(fstatus.getPath().toString());
     }
 
     protected boolean acceptFile(String filePathStr)

--- a/library/src/test/java/com/datatorrent/lib/io/fs/AbstractFileInputOperatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/io/fs/AbstractFileInputOperatorTest.java
@@ -895,6 +895,8 @@ public class AbstractFileInputOperatorTest
     for (int file = 0; file < 10; file++) {
       FileUtils.write(new File(testMeta.dir, file + "_partition_00" + rand.nextInt(100)), "");
     }
+    final String directoryName = "0_partition_100001";
+    FileUtils.forceMkdir(new File(testMeta.dir, directoryName));
 
     List<Partition<AbstractFileInputOperator<String>>> partitions = Lists.newArrayList();
     partitions.add(new DefaultPartition<AbstractFileInputOperator<String>>(oper));
@@ -909,6 +911,11 @@ public class AbstractFileInputOperatorTest
       Set<String> consumed = Sets.newHashSet();
       LinkedHashSet<Path> files = p.getPartitionedInstance().getScanner().scan(FileSystem.getLocal(new Configuration(false)), path, consumed);
       Assert.assertEquals("partition " + files, 5, files.size());
+      HashSet<String> fileNameSet = Sets.newHashSet();
+      for (Path file : files) {
+        fileNameSet.add(file.getName());
+      }
+      Assert.assertFalse("The directory is skipped from file list ", fileNameSet.contains(directoryName));
     }
   }
 


### PR DESCRIPTION
The default DirectoryScanner defined in AbstractFileInputOperator does not handle directories correctly. If there is a directory in the configured path, it gets added as a file in pendingFile list and when operator tries to open it for reading it fails, the operator keeps retrying for configured number of time and then ignore this file.

The fix would be to not return directory name in scanned file names in the first place.
