### PR TITLE
APEXMALHAR-2291 Fix for Exactly-once processing of JdbcPOJOInsertOutput Operator.

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/db/AbstractPassThruTransactionableStoreOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/AbstractPassThruTransactionableStoreOutputOperator.java
@@ -49,9 +49,11 @@ public abstract class AbstractPassThruTransactionableStoreOutputOperator<T, S ex
   @Override
   public void endWindow()
   {
-    store.storeCommittedWindowId(appId, operatorId, currentWindowId);
-    store.commitTransaction();
-    committedWindowId = currentWindowId;
+    if ( committedWindowId < currentWindowId ) {
+      store.storeCommittedWindowId(appId, operatorId, currentWindowId);
+      store.commitTransaction();
+      committedWindowId = currentWindowId;
+    }
     super.endWindow();
   }
 


### PR DESCRIPTION
Added a check in endWindow() to not to commit if committed window id is greater than current window id.
@bhupeshchawda @chinmaykolhatkar Please review. Have done the code changes as discussed on mail thread, travis build has passed, have written corresponding unit test case
