### PR TITLE
APEXMALHAR-2312 Fix NullPointerException for FileSplitterInput Operat…

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/io/fs/FileSplitterInput.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/FileSplitterInput.java
@@ -393,6 +393,18 @@ public class FileSplitterInput extends AbstractFileSplitter implements InputOper
       if (lastScannedInfo == null) { // first iteration started
         return true;
       }
+
+      LOG.debug("Directory path: {} Sub-Directory or File path: {}", lastScannedInfo.getDirectoryPath(), lastScannedInfo.getFilePath());
+
+      /*
+       * As referenceTimes is now concurrentHashMap, it throws exception if key passed is null.
+       * So in case where the last scanned directory is null which likely possible when
+       * only file name is specified instead of directory path.
+       */
+      if (lastScannedInfo.getDirectoryPath() == null) {
+        return true;
+      }
+
       Map<String, Long> referenceTime = referenceTimes.get(lastScannedInfo.getDirectoryPath());
       if (referenceTime != null) {
         return referenceTime.get(lastScannedInfo.getFilePath()) != null;


### PR DESCRIPTION
## Problem Statement:

NullPointerException seen in FileSplitterInput only if the file path is specified for attribute <files> instead of directory path.
## Description:

1) TimeBasedDirectoryScanner threads part of scanservice tries to scan the directories/files.
2) Each thread checks with help of isIterationCompleted() [referenceTimes] method whether scanned of last iteration are processed by operator thread.
3) Previously it used to work because HashMap (referenceTimes) used to return null even if last scanned directory path is null.
4) Recently referenceTimes is changed to ConcurrentHashMap, so get() doesn't allow null key's passed to ConcurrentHashMap get() method.
5) Hence NullPointerException is seen as if only file path is provided directory path would be empty hence key would be empty.
## Solution:

Pre-check that directory path is null then we have completed last iterations if only filepath is provided.
## Testing logs with fix for files/directories/sub-directories:

2016-10-21 11:20:38,382 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: Directory path: /user/deepak/files Sub-Directory or File path: /user/deepak/files/CustomerTxnData2
2016-10-21 11:20:38,382 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: Scan started for input /user/deepak/files
2016-10-21 11:20:38,386 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: scan /user/deepak/files
2016-10-21 11:20:33,372 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: discovered /user/deepak/files/CustomerTxnData 1477028632605
2016-10-21 11:20:33,372 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: discovered /user/deepak/files/CustomerTxnData1 1477028642067
2016-10-21 11:20:33,373 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: discovered /user/deepak/files/CustomerTxnData2 1477028645290
2016-10-21 11:20:33,373 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: scan complete 0 3

....

2016-10-21 11:25:50,697 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: Directory path: null Sub-Directory or File path: /user/deepak/files/CustomerTxnData
2016-10-21 11:25:50,697 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: Scan started for input /user/deepak/files/CustomerTxnData
2016-10-21 11:25:50,702 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: scan /user/deepak/files/CustomerTxnData
2016-10-21 11:25:50,704 DEBUG com.datatorrent.lib.io.fs.FileSplitterInput: scan complete
