### PR TITLE
APEXMALHAR-2322 Suppress strict Javadoc checking in Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <apex.core.version>3.4.0</apex.core.version>
     <semver.plugin.skip>false</semver.plugin.skip>
     <surefire.args>-Xmx2048m</surefire.args>
+    <additionalparam>-Xdoclint:none</additionalparam>
   </properties>
 
   <build>


### PR DESCRIPTION
Running "mvn javadoc:aggregate" with Java 8 produces many errors due to stricter checking; this change restores the prior liberal behavior.
@tweise please review
