### PR TITLE
APEXMALHAR-2326 Use elasticMQ as a mock SQS server instead of using creds

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -378,6 +378,12 @@
         </exclusion>
       </exclusions> 
     </dependency>
+    <dependency>
+      <groupId>org.elasticmq</groupId>
+      <artifactId>elasticmq-rest-sqs_2.11</artifactId>
+      <version>0.10.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
@tweise  this is to fix the test failures in SQSStringInputOperatorTest. Pls review and merge