### PR TITLE
APEXMALHAR-2327 #resolve #comment BucketsFileSystem.writeBucketData()…

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/fileaccess/FileAccess.java
+++ b/library/src/main/java/com/datatorrent/lib/fileaccess/FileAccess.java
@@ -147,11 +147,21 @@ public interface FileAccess extends Closeable
   {
     /**
      * Appends key/value pair to the underlying file.
+     * @deprecated use {@link FileWriter#append(Slice, Slice)} instead.
      * @param key
      * @param value
      * @throws IOException
      */
+    @Deprecated
     void append(byte[] key, byte[] value) throws IOException;
+
+    /**
+     * Appends key/value pair to the underlying file.
+     * @param key
+     * @param value
+     * @throws IOException
+     */
+    void append(Slice key, Slice value) throws IOException;
 
     /**
      * Returns number of bytes written to the underlying stream.

--- a/library/src/main/java/com/datatorrent/lib/fileaccess/TFileWriter.java
+++ b/library/src/main/java/com/datatorrent/lib/fileaccess/TFileWriter.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.io.file.tfile.TFile.Writer;
 
+import com.datatorrent.netlet.util.Slice;
+
 /**
  * TFileWriter
  *
@@ -56,6 +58,12 @@ public final class TFileWriter implements FileAccess.FileWriter
   public void append(byte[] key, byte[] value) throws IOException
   {
     writer.append(key, value);
+  }
+
+  @Override
+  public void append(Slice key, Slice value) throws IOException
+  {
+    writer.append(key.buffer, key.offset, key.length, value.buffer, value.offset, value.length);
   }
 
   @Override

--- a/library/src/main/java/org/apache/apex/malhar/lib/state/managed/BucketsFileSystem.java
+++ b/library/src/main/java/org/apache/apex/malhar/lib/state/managed/BucketsFileSystem.java
@@ -173,7 +173,7 @@ public class BucketsFileSystem implements ManagedStateComponent
           dataSize += key.length;
           dataSize += value.length;
 
-          fileWriter.append(key.toByteArray(), value.toByteArray());
+          fileWriter.append(key, value);
           if (firstKey == null) {
             firstKey = key;
           }
@@ -197,7 +197,7 @@ public class BucketsFileSystem implements ManagedStateComponent
           dataSize += key.length;
           dataSize += value.length;
 
-          fileWriter.append(key.toByteArray(), value.toByteArray());
+          fileWriter.append(key, value);
           if (firstKey == null) {
             firstKey = key;
           }


### PR DESCRIPTION
… call Slice.toByteArray() cause allocate unnecessary memory