### PR TITLE
APEXMALHAR-2330 JdbcPOJOPollInputOperator fails with NullPointerExcep…

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJOPollInputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJOPollInputOperator.java
@@ -195,11 +195,11 @@ public class JdbcPOJOPollInputOperator extends AbstractJdbcPollInputOperator<Obj
         int type = rsMetaData.getColumnType(i);
         String name = rsMetaData.getColumnName(i);
         LOG.debug("column name {} type {}", name, type);
-        nameToType.put(name, type);
+        nameToType.put(name.toUpperCase(), type);
       }
 
       for (FieldInfo fieldInfo : fieldInfos) {
-        columnDataTypes.add(nameToType.get(fieldInfo.getColumnName()));
+        columnDataTypes.add(nameToType.get(fieldInfo.getColumnName().toUpperCase()));
       }
     }
   }


### PR DESCRIPTION
**Problem:** 
JdbcPOJOPollInputOperator fails with NullPointerException using PostgreSQL driver.

**Problem Description:**
1) When JdbcPOJOPollInputOperator tries to populateColumnDataTypes, column names retrieved from resultmetadata from database ( this case : Postgres) are all lowercase.
2) Whereas columnDatatypes specified in fieldinfos might be in same case.
3) Internally hashmap ( nameToType) is used which mismatches if column name and fieldinfo are not in same case. Hence columnDataTypes is empty which causes null exception in activate call.

**Solution:**
Using similar case for hashmap and column names irrespective of any database used for JdbcPOJOPollInputOperator.

**Testing:**
Tested with Database-to-hdfs app also with instrumented logs.