### PR TITLE
APEXMALHAR-2342 Check file exists to prevent null pointer exception …

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/io/fs/AbstractFileOutputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/AbstractFileOutputOperator.java
@@ -412,7 +412,7 @@ public abstract class AbstractFileOutputOperator<INPUT> extends BaseOperator imp
               activePath = new Path(filePath + Path.SEPARATOR + seenPartFileName);
             }
 
-            if (activePath != null && fs.getFileStatus(activePath).getLen() > maxLength) {
+            if (activePath != null && fs.exists(activePath) && fs.getFileStatus(activePath).getLen() > maxLength) {
               //Handle the case when restoring to a checkpoint where the current rolling file
               //already has a length greater than max length.
               LOG.debug("rotating file at setup.");


### PR DESCRIPTION
…in AbstractFileOutputOperator recovery setup