### PR TITLE
APEXMALHAR-2377-Move LopParser to org.apache.apex.malhar.contrib.parser

### DIFF
--- a/contrib/src/main/java/org/apache/apex/malhar/contrib/parser/LogParser.java
+++ b/contrib/src/main/java/org/apache/apex/malhar/contrib/parser/LogParser.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.datatorrent.contrib.parser;
+package org.apache.apex.malhar.contrib.parser;
 
 import java.io.IOException;
 import javax.validation.constraints.NotNull;

--- a/contrib/src/main/java/org/apache/apex/malhar/contrib/parser/LogSchemaDetails.java
+++ b/contrib/src/main/java/org/apache/apex/malhar/contrib/parser/LogSchemaDetails.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.datatorrent.contrib.parser;
+package org.apache.apex.malhar.contrib.parser;
 
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;

--- a/contrib/src/test/java/org/apache/apex/malhar/contrib/parser/LogParserTest.java
+++ b/contrib/src/test/java/org/apache/apex/malhar/contrib/parser/LogParserTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.datatorrent.contrib.parser;
+package org.apache.apex.malhar.contrib.parser;
 
 import org.codehaus.jettison.json.JSONException;
 import org.jooq.exception.IOException;
@@ -25,6 +25,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
+
+import org.apache.apex.malhar.contrib.parser.LogParser;
+import org.apache.apex.malhar.contrib.parser.LogSchemaDetails;
 
 import com.datatorrent.lib.appdata.schemas.SchemaUtils;
 import com.datatorrent.lib.testbench.CollectorTestSink;


### PR DESCRIPTION
Refer discussion in [PR](https://github.com/apache/apex-malhar/pull/520)
Moved LogParser Operator from com.datatorrent.contrib.parser package to org.apache.apex.malhar.contrib.parser