### PR TITLE
APEXMALHAR-2239 Handle Null pointer exception in JDBCPojoInputOperator

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJOInputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPOJOInputOperator.java
@@ -175,8 +175,16 @@ public class JdbcPOJOInputOperator extends AbstractJdbcInputOperator<Object>
       }
 
       if (query != null) {
+        List<Integer> invalidFields = Lists.newArrayList();
         for (FieldInfo fieldInfo : fieldInfos) {
-          columnDataTypes.add(nameToType.get(fieldInfo.getColumnName()));
+          if (nameToType.get(fieldInfo.getColumnName()) == null) {
+            invalidFields.add(fieldInfos.indexOf(fieldInfo));
+          } else {
+            columnDataTypes.add(nameToType.get(fieldInfo.getColumnName()));
+          }
+        }
+        for (int invalidField : invalidFields) {
+          fieldInfos.remove(invalidField);
         }
       }
     }

--- a/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcPojoOperatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcPojoOperatorTest.java
@@ -597,53 +597,53 @@ public class JdbcPojoOperatorTest extends JdbcOperatorTest
     Assert.assertEquals("rows from db", 10, sink.collectedTuples.size());
   }
 
-  @Test
-  public void testJdbcPojoInputOperatorExtraField()
-  {
-    JdbcStore store = new JdbcStore();
-    store.setDatabaseDriver(DB_DRIVER);
-    store.setDatabaseUrl(URL);
-
-    Attribute.AttributeMap.DefaultAttributeMap attributeMap = new Attribute.AttributeMap.DefaultAttributeMap();
-    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
-    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(
-        OPERATOR_ID, attributeMap);
-
-    insertEvents(10, true, 0);
-
-    JdbcPOJOInputOperator inputOperator = new JdbcPOJOInputOperator();
-    inputOperator.setStore(store);
-    inputOperator.setQuery("select ID,STARTDATE,STARTTIME,STARTTIMESTAMP from " + TABLE_POJO_NAME);
-    inputOperator.setTableName(TABLE_POJO_NAME);
-
-    List<FieldInfo> fieldInfos = Lists.newArrayList();
-    fieldInfos.add(new FieldInfo("ID", "id", null));
-    fieldInfos.add(new FieldInfo("STARTDATE", "startDate", null));
-    fieldInfos.add(new FieldInfo("STARTTIME", "startTime", null));
-    fieldInfos.add(new FieldInfo("STARTTIMESTAMP", "startTimestamp", null));
-
-    // Extra field "score" should not cause Runtime exception
-    fieldInfos.add(new FieldInfo("SCORE", "score", FieldInfo.SupportType.DOUBLE));
-    inputOperator.setFieldInfos(fieldInfos);
-
-    inputOperator.setFetchSize(5);
-
-    CollectorTestSink<Object> sink = new CollectorTestSink<>();
-    inputOperator.outputPort.setSink(sink);
-
-    Attribute.AttributeMap.DefaultAttributeMap portAttributes = new Attribute.AttributeMap.DefaultAttributeMap();
-    portAttributes.put(Context.PortContext.TUPLE_CLASS, TestPOJOEvent.class);
-    TestPortContext tpc = new TestPortContext(portAttributes);
-
-    inputOperator.setup(context);
-    inputOperator.outputPort.setup(tpc);
-
-    inputOperator.activate(context);
-
-    // Invalid field "score" has been removed correctly
-    Assert.assertEquals("fieldInfos size", 4, fieldInfos.size());
-  }
-
+//  @Test
+//  public void testJdbcPojoInputOperatorExtraField()
+//  {
+//    JdbcStore store = new JdbcStore();
+//    store.setDatabaseDriver(DB_DRIVER);
+//    store.setDatabaseUrl(URL);
+//
+//    Attribute.AttributeMap.DefaultAttributeMap attributeMap = new Attribute.AttributeMap.DefaultAttributeMap();
+//    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
+//    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(
+//        OPERATOR_ID, attributeMap);
+//
+//    insertEvents(10, true, 0);
+//
+//    JdbcPOJOInputOperator inputOperator = new JdbcPOJOInputOperator();
+//    inputOperator.setStore(store);
+//    inputOperator.setQuery("select ID,STARTDATE,STARTTIME,STARTTIMESTAMP from " + TABLE_POJO_NAME);
+//    inputOperator.setTableName(TABLE_POJO_NAME);
+//
+//    List<FieldInfo> fieldInfos = Lists.newArrayList();
+//    fieldInfos.add(new FieldInfo("ID", "id", null));
+//    fieldInfos.add(new FieldInfo("STARTDATE", "startDate", null));
+//    fieldInfos.add(new FieldInfo("STARTTIME", "startTime", null));
+//    fieldInfos.add(new FieldInfo("STARTTIMESTAMP", "startTimestamp", null));
+//
+//    // Extra field "score" should not cause Runtime exception
+//    fieldInfos.add(new FieldInfo("SCORE", "score", FieldInfo.SupportType.DOUBLE));
+//    inputOperator.setFieldInfos(fieldInfos);
+//
+//    inputOperator.setFetchSize(5);
+//
+//    CollectorTestSink<Object> sink = new CollectorTestSink<>();
+//    inputOperator.outputPort.setSink(sink);
+//
+//    Attribute.AttributeMap.DefaultAttributeMap portAttributes = new Attribute.AttributeMap.DefaultAttributeMap();
+//    portAttributes.put(Context.PortContext.TUPLE_CLASS, TestPOJOEvent.class);
+//    TestPortContext tpc = new TestPortContext(portAttributes);
+//
+//    inputOperator.setup(context);
+//    inputOperator.outputPort.setup(tpc);
+//
+//    inputOperator.activate(context);
+//
+//    // Invalid field "score" has been removed correctly
+//    Assert.assertEquals("fieldInfos size", 4, fieldInfos.size());
+//  }
+//
   @Test
   public void testJdbcPojoInputOperator()
   {

--- a/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcPojoOperatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcPojoOperatorTest.java
@@ -597,53 +597,53 @@ public class JdbcPojoOperatorTest extends JdbcOperatorTest
     Assert.assertEquals("rows from db", 10, sink.collectedTuples.size());
   }
 
-//  @Test
-//  public void testJdbcPojoInputOperatorExtraField()
-//  {
-//    JdbcStore store = new JdbcStore();
-//    store.setDatabaseDriver(DB_DRIVER);
-//    store.setDatabaseUrl(URL);
-//
-//    Attribute.AttributeMap.DefaultAttributeMap attributeMap = new Attribute.AttributeMap.DefaultAttributeMap();
-//    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
-//    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(
-//        OPERATOR_ID, attributeMap);
-//
-//    insertEvents(10, true, 0);
-//
-//    JdbcPOJOInputOperator inputOperator = new JdbcPOJOInputOperator();
-//    inputOperator.setStore(store);
-//    inputOperator.setQuery("select ID,STARTDATE,STARTTIME,STARTTIMESTAMP from " + TABLE_POJO_NAME);
-//    inputOperator.setTableName(TABLE_POJO_NAME);
-//
-//    List<FieldInfo> fieldInfos = Lists.newArrayList();
-//    fieldInfos.add(new FieldInfo("ID", "id", null));
-//    fieldInfos.add(new FieldInfo("STARTDATE", "startDate", null));
-//    fieldInfos.add(new FieldInfo("STARTTIME", "startTime", null));
-//    fieldInfos.add(new FieldInfo("STARTTIMESTAMP", "startTimestamp", null));
-//
-//    // Extra field "score" should not cause Runtime exception
-//    fieldInfos.add(new FieldInfo("SCORE", "score", FieldInfo.SupportType.DOUBLE));
-//    inputOperator.setFieldInfos(fieldInfos);
-//
-//    inputOperator.setFetchSize(5);
-//
-//    CollectorTestSink<Object> sink = new CollectorTestSink<>();
-//    inputOperator.outputPort.setSink(sink);
-//
-//    Attribute.AttributeMap.DefaultAttributeMap portAttributes = new Attribute.AttributeMap.DefaultAttributeMap();
-//    portAttributes.put(Context.PortContext.TUPLE_CLASS, TestPOJOEvent.class);
-//    TestPortContext tpc = new TestPortContext(portAttributes);
-//
-//    inputOperator.setup(context);
-//    inputOperator.outputPort.setup(tpc);
-//
-//    inputOperator.activate(context);
-//
-//    // Invalid field "score" has been removed correctly
-//    Assert.assertEquals("fieldInfos size", 4, fieldInfos.size());
-//  }
-//
+  @Test
+  public void testJdbcPojoInputOperatorExtraField()
+  {
+    JdbcStore store = new JdbcStore();
+    store.setDatabaseDriver(DB_DRIVER);
+    store.setDatabaseUrl(URL);
+
+    Attribute.AttributeMap.DefaultAttributeMap attributeMap = new Attribute.AttributeMap.DefaultAttributeMap();
+    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
+    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(
+        OPERATOR_ID, attributeMap);
+
+    insertEvents(10, true, 0);
+
+    JdbcPOJOInputOperator inputOperator = new JdbcPOJOInputOperator();
+    inputOperator.setStore(store);
+    inputOperator.setQuery("select ID,STARTDATE,STARTTIME,STARTTIMESTAMP from " + TABLE_POJO_NAME);
+    inputOperator.setTableName(TABLE_POJO_NAME);
+
+    List<FieldInfo> fieldInfos = Lists.newArrayList();
+    fieldInfos.add(new FieldInfo("ID", "id", null));
+    fieldInfos.add(new FieldInfo("STARTDATE", "startDate", null));
+    fieldInfos.add(new FieldInfo("STARTTIME", "startTime", null));
+    fieldInfos.add(new FieldInfo("STARTTIMESTAMP", "startTimestamp", null));
+
+    // Extra field "score" should not cause Runtime exception
+    fieldInfos.add(new FieldInfo("SCORE", "score", FieldInfo.SupportType.DOUBLE));
+    inputOperator.setFieldInfos(fieldInfos);
+
+    inputOperator.setFetchSize(5);
+
+    CollectorTestSink<Object> sink = new CollectorTestSink<>();
+    inputOperator.outputPort.setSink(sink);
+
+    Attribute.AttributeMap.DefaultAttributeMap portAttributes = new Attribute.AttributeMap.DefaultAttributeMap();
+    portAttributes.put(Context.PortContext.TUPLE_CLASS, TestPOJOEvent.class);
+    TestPortContext tpc = new TestPortContext(portAttributes);
+
+    inputOperator.setup(context);
+    inputOperator.outputPort.setup(tpc);
+
+    inputOperator.activate(context);
+
+    // Invalid field "score" has been removed correctly
+    Assert.assertEquals("fieldInfos size", 4, fieldInfos.size());
+  }
+
   @Test
   public void testJdbcPojoInputOperator()
   {

--- a/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcPojoOperatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcPojoOperatorTest.java
@@ -598,6 +598,53 @@ public class JdbcPojoOperatorTest extends JdbcOperatorTest
   }
 
   @Test
+  public void testJdbcPojoInputOperatorExtraField()
+  {
+    JdbcStore store = new JdbcStore();
+    store.setDatabaseDriver(DB_DRIVER);
+    store.setDatabaseUrl(URL);
+
+    Attribute.AttributeMap.DefaultAttributeMap attributeMap = new Attribute.AttributeMap.DefaultAttributeMap();
+    attributeMap.put(DAG.APPLICATION_ID, APP_ID);
+    OperatorContextTestHelper.TestIdOperatorContext context = new OperatorContextTestHelper.TestIdOperatorContext(
+        OPERATOR_ID, attributeMap);
+
+    insertEvents(10, true, 0);
+
+    JdbcPOJOInputOperator inputOperator = new JdbcPOJOInputOperator();
+    inputOperator.setStore(store);
+    inputOperator.setQuery("select ID,STARTDATE,STARTTIME,STARTTIMESTAMP from " + TABLE_POJO_NAME);
+    inputOperator.setTableName(TABLE_POJO_NAME);
+
+    List<FieldInfo> fieldInfos = Lists.newArrayList();
+    fieldInfos.add(new FieldInfo("ID", "id", null));
+    fieldInfos.add(new FieldInfo("STARTDATE", "startDate", null));
+    fieldInfos.add(new FieldInfo("STARTTIME", "startTime", null));
+    fieldInfos.add(new FieldInfo("STARTTIMESTAMP", "startTimestamp", null));
+
+    // Extra field "score" should not cause Runtime exception
+    fieldInfos.add(new FieldInfo("SCORE", "score", FieldInfo.SupportType.DOUBLE));
+    inputOperator.setFieldInfos(fieldInfos);
+
+    inputOperator.setFetchSize(5);
+
+    CollectorTestSink<Object> sink = new CollectorTestSink<>();
+    inputOperator.outputPort.setSink(sink);
+
+    Attribute.AttributeMap.DefaultAttributeMap portAttributes = new Attribute.AttributeMap.DefaultAttributeMap();
+    portAttributes.put(Context.PortContext.TUPLE_CLASS, TestPOJOEvent.class);
+    TestPortContext tpc = new TestPortContext(portAttributes);
+
+    inputOperator.setup(context);
+    inputOperator.outputPort.setup(tpc);
+
+    inputOperator.activate(context);
+
+    // Invalid field "score" has been removed correctly
+    Assert.assertEquals("fieldInfos size", 4, fieldInfos.size());
+  }
+
+  @Test
   public void testJdbcPojoInputOperator()
   {
     JdbcStore store = new JdbcStore();


### PR DESCRIPTION
This is to handle the exception when we set a query to fetch rows and have additional columns in fieldInfos.