### PR TITLE
Changing the version of twitter4j

### DIFF
--- a/demos/twitter/pom.xml
+++ b/demos/twitter/pom.xml
@@ -43,13 +43,13 @@
       <!-- required by twitter demo -->
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.4</version>
+      <version>4.0.6</version>
     </dependency>
     <dependency>
       <!-- required by twitter demo -->
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-stream</artifactId>
-      <version>4.0.4</version>
+      <version>4.0.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>


### PR DESCRIPTION
I request you to please change the version of twitter4j-core and twitter4j-stream in dependency from 4.0.4 to 4.0.6.

As there was a known error in 4.0.4 which was fixed in the new version of 4.0.6