### PR TITLE
APEXMALHAR-2418 Updated twitter4j library version for twitter demo ap…

### DIFF
--- a/demos/twitter/pom.xml
+++ b/demos/twitter/pom.xml
@@ -43,13 +43,13 @@
       <!-- required by twitter demo -->
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
-      <version>4.0.4</version>
+      <version>4.0.6</version>
     </dependency>
     <dependency>
       <!-- required by twitter demo -->
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-stream</artifactId>
-      <version>4.0.4</version>
+      <version>4.0.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>


### PR DESCRIPTION
There was a known issue of Build Failure for twitter version 4.0.4.
So for successfully building and launching the application, need to change the version from 4.0.4 to 4.0.6. 
It has been tested.