### PR TITLE
APEXMALHAR-2460 Redshift output module unable to emit tuples.

### DIFF
--- a/library/src/main/java/org/apache/apex/malhar/lib/fs/s3/S3Reconciler.java
+++ b/library/src/main/java/org/apache/apex/malhar/lib/fs/s3/S3Reconciler.java
@@ -174,11 +174,11 @@ public class S3Reconciler extends AbstractReconciler<FSRecordCompactionOperator.
     while (doneTuples.peek() != null) {
       FSRecordCompactionOperator.OutputMetaData metaData = doneTuples.poll();
       removeIntermediateFiles(metaData);
-      /*if (outputPort.isConnected()) {
+      if (outputPort.isConnected()) {
         // Emit the meta data with S3 path
         metaData.setPath(getDirectoryName() + Path.SEPARATOR + metaData.getFileName());
         outputPort.emit(metaData);
-      }*/
+      }
     }
   }
 


### PR DESCRIPTION
Tested with newly created application kinesis-to-redshift app-template (under separate PR).
