### PR TITLE
APEXMALHAR-2473 Support for global cache meta information in db Cache…

### DIFF
--- a/contrib/src/main/java/com/datatorrent/contrib/enrich/AbstractEnricher.java
+++ b/contrib/src/main/java/com/datatorrent/contrib/enrich/AbstractEnricher.java
@@ -73,9 +73,10 @@ public abstract class AbstractEnricher<INPUT, OUTPUT> extends BaseOperator imple
   /**
    * Helper variables.
    */
-  private transient CacheManager cacheManager;
   protected transient List<FieldInfo> lookupFieldInfo = new ArrayList<>();
   protected transient List<FieldInfo> includeFieldInfo = new ArrayList<>();
+
+  private CacheManager cacheManager = new NullValuesCacheManager();
 
   /**
    * This method needs to be called by implementing class for processing a tuple for enrichment.
@@ -154,7 +155,6 @@ public abstract class AbstractEnricher<INPUT, OUTPUT> extends BaseOperator imple
   {
     super.setup(context);
 
-    cacheManager = new NullValuesCacheManager();
     CacheStore primaryCache = new CacheStore();
 
     // set expiration to one day.
@@ -185,13 +185,18 @@ public abstract class AbstractEnricher<INPUT, OUTPUT> extends BaseOperator imple
     try {
       cacheManager.initialize();
     } catch (IOException e) {
-      throw new RuntimeException("Unable to initialize primary cache", e);
+      throw new RuntimeException("Unable to initialize cache manager", e);
     }
   }
 
   @Override
   public void deactivate()
   {
+    try {
+      cacheManager.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to close cache manager", e);
+    }
   }
 
   /**
@@ -319,5 +324,15 @@ public abstract class AbstractEnricher<INPUT, OUTPUT> extends BaseOperator imple
   public void setCacheSize(int cacheSize)
   {
     this.cacheSize = cacheSize;
+  }
+
+  public CacheManager getCacheManager()
+  {
+    return cacheManager;
+  }
+
+  public void setCacheManager(CacheManager cacheManager)
+  {
+    this.cacheManager = cacheManager;
   }
 }


### PR DESCRIPTION
…Manager

  1. Uses Component interface and newly implemented CacheContext to pass properties to the Stores by calling setup(CacheContext).
  2. APEXMALHAR-2474: FSLoader implements Component to get numInitLinesToCache from CacheManager and use it in initial load.
	Add implementation of get() function so data will also be loaded after initial load.
  3. APEXMALHAR-2475: CacheStore implements Component for passing readOnly and numInitLinesToCache.
	Added NO_EVICTION expire strategy. This strategy will be set in setup(CacheContext) if readOnly is true.

@PramodSSImmaneni: please review