### PR TITLE
APEXMALHAR-2487 Added support for Snappy compression in FilterStreamProvider

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/io/fs/FilterStreamCodec.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/FilterStreamCodec.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/library/src/main/java/com/datatorrent/lib/io/fs/FilterStreamCodec.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/FilterStreamCodec.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -105,7 +105,8 @@ public class FilterStreamCodec
     @Override
     public FilterStreamContext<CipherOutputStream> getFilterStreamContext(OutputStream outputStream) throws IOException
     {
-      return new FilterStreamContext.SimpleFilterStreamContext<CipherOutputStream>(new CipherOutputStream(outputStream, cipher));
+      return new FilterStreamContext.SimpleFilterStreamContext<CipherOutputStream>(
+          new CipherOutputStream(outputStream, cipher));
     }
 
     @Override
@@ -131,11 +132,11 @@ public class FilterStreamCodec
       super(out);
     }
 
-    public void finish() throws IOException {
+    public void finish() throws IOException
+    {
       ((CompressionOutputStream)out).finish();
     }
   }
-
 
   public static class SnappyFilterStreamContext extends FilterStreamContext.BaseFilterStreamContext<SnappyFilterStream>
   {

--- a/library/src/main/java/com/datatorrent/lib/io/fs/FilterStreamCodec.java
+++ b/library/src/main/java/com/datatorrent/lib/io/fs/FilterStreamCodec.java
@@ -18,12 +18,18 @@
  */
 package com.datatorrent.lib.io.fs;
 
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.zip.GZIPOutputStream;
 
 import javax.crypto.Cipher;
 import javax.crypto.CipherOutputStream;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.CompressionOutputStream;
+import org.apache.hadoop.io.compress.SnappyCodec;
+import org.apache.hadoop.io.compress.snappy.SnappyCompressor;
 
 /**
  * Filters for compression and encryption.
@@ -104,6 +110,73 @@ public class FilterStreamCodec
 
     @Override
     public void reclaimFilterStreamContext(FilterStreamContext<CipherOutputStream> filterStreamContext)
+    {
+
+    }
+  }
+
+  public static class SnappyFilterStream extends FilterOutputStream
+  {
+    /**
+     * Creates an output stream filter built on top of the specified
+     * underlying output stream.
+     *
+     * @param out the underlying output stream to be assigned to
+     *            the field <tt>this.out</tt> for later use, or
+     *            <code>null</code> if this instance is to be
+     *            created without an underlying stream.
+     */
+    public SnappyFilterStream(CompressionOutputStream out)
+    {
+      super(out);
+    }
+
+    public void finish() throws IOException {
+      ((CompressionOutputStream)out).finish();
+    }
+  }
+
+
+  public static class SnappyFilterStreamContext extends FilterStreamContext.BaseFilterStreamContext<SnappyFilterStream>
+  {
+    public SnappyFilterStreamContext(OutputStream outputStream) throws IOException
+    {
+      SnappyCodec codec = new SnappyCodec();
+      codec.setConf(new Configuration());
+      try {
+        filterStream = new SnappyFilterStream(
+            codec.createOutputStream(outputStream, new SnappyCompressor(256 * 1024)));
+      } catch (IOException e) {
+        throw e;
+      }
+    }
+
+    @Override
+    public void finalizeContext() throws IOException
+    {
+      try {
+        filterStream.finish();
+      } catch (IOException e) {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * A provider for Snappy filter
+   */
+  public static class SnappyFilterStreamProvider implements FilterStreamProvider<SnappyFilterStream,
+      OutputStream>
+  {
+    @Override
+    public FilterStreamContext<SnappyFilterStream> getFilterStreamContext(OutputStream outputStream)
+        throws IOException
+    {
+      return new SnappyFilterStreamContext(outputStream);
+    }
+
+    @Override
+    public void reclaimFilterStreamContext(FilterStreamContext<SnappyFilterStream> filterStreamContext)
     {
 
     }

--- a/library/src/test/java/com/datatorrent/lib/io/fs/AbstractFileOutputOperatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/io/fs/AbstractFileOutputOperatorTest.java
@@ -1641,6 +1641,10 @@ public class AbstractFileOutputOperatorTest
   @Test
   public void testSnappyStreamProvider() throws IOException
   {
+    if (checkNativeSnappy()) {
+      return;
+    }
+
     EvenOddHDFSExactlyOnceWriter writer = new EvenOddHDFSExactlyOnceWriter();
     writer.setFilterStreamProvider(new FilterStreamCodec.SnappyFilterStreamProvider());
 
@@ -1658,20 +1662,29 @@ public class AbstractFileOutputOperatorTest
     checkSnappyFile(oddFile, oddOffsets, 1, 5, 1000);
   }
 
-  @Test
-  public void testSnappyCompressionSimple() throws IOException
+  private boolean checkNativeSnappy()
   {
-    File snappyFile = new File(testMeta.getDir(), "snappyTestFile.snappy");
-
     try {
       SnappyCodec.checkNativeCodeLoaded();
     } catch (UnsatisfiedLinkError u) {
-      System.out.println("WARNING: Skipping Snappy compression test since native libraries were not found.");
-      return;
+      LOG.error("WARNING: Skipping Snappy compression test since native libraries were not found.");
+      return true;
     } catch (RuntimeException e) {
-      System.out.println("WARNING: Skipping Snappy compression test since native libraries were not found.");
+      LOG.error("WARNING: Skipping Snappy compression test since native libraries were not found.");
+      return true;
+    }
+    return false;
+  }
+
+
+  @Test
+  public void testSnappyCompressionSimple() throws IOException
+  {
+    if (checkNativeSnappy()) {
       return;
     }
+
+    File snappyFile = new File(testMeta.getDir(), "snappyTestFile.snappy");
 
     BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(snappyFile));
     Configuration conf = new Configuration();

--- a/library/src/test/java/com/datatorrent/lib/io/fs/AbstractFileOutputOperatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/io/fs/AbstractFileOutputOperatorTest.java
@@ -23,7 +23,6 @@ import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.FilterOutputStream;
@@ -60,7 +59,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionInputStream;
-import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.io.compress.SnappyCodec;
 import org.apache.hadoop.util.ReflectionUtils;
 
@@ -1688,7 +1686,7 @@ public class AbstractFileOutputOperatorTest
 
     BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(snappyFile));
     Configuration conf = new Configuration();
-    CompressionCodec codec = (CompressionCodec) ReflectionUtils.newInstance(SnappyCodec.class, conf);
+    CompressionCodec codec = (CompressionCodec)ReflectionUtils.newInstance(SnappyCodec.class, conf);
     FilterStreamCodec.SnappyFilterStream filterStream = new FilterStreamCodec.SnappyFilterStream(
         codec.createOutputStream(os));
 
@@ -1845,7 +1843,7 @@ public class AbstractFileOutputOperatorTest
     FileInputStream fis;
     InputStream gss = null;
     Configuration conf = new Configuration();
-    CompressionCodec codec = (CompressionCodec) ReflectionUtils.newInstance(SnappyCodec.class, conf);
+    CompressionCodec codec = (CompressionCodec)ReflectionUtils.newInstance(SnappyCodec.class, conf);
     CompressionInputStream snappyIs = null;
 
     BufferedReader br = null;

--- a/library/src/test/java/com/datatorrent/lib/io/fs/AbstractFileOutputOperatorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/io/fs/AbstractFileOutputOperatorTest.java
@@ -18,10 +18,13 @@
  */
 package com.datatorrent.lib.io.fs;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.FilterOutputStream;
 import java.io.IOException;
@@ -55,6 +58,11 @@ import org.slf4j.LoggerFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionInputStream;
+import org.apache.hadoop.io.compress.GzipCodec;
+import org.apache.hadoop.io.compress.SnappyCodec;
+import org.apache.hadoop.util.ReflectionUtils;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -74,6 +82,7 @@ import com.datatorrent.lib.util.TestUtils.TestInfo;
 import com.datatorrent.netlet.util.DTThrowable;
 
 import static com.datatorrent.lib.helper.OperatorContextTestHelper.mockOperatorContext;
+import static org.junit.Assert.assertEquals;
 
 public class AbstractFileOutputOperatorTest
 {
@@ -1585,20 +1594,9 @@ public class AbstractFileOutputOperatorTest
     Assert.assertEquals("Part file names", fileNames, getFileNames(files));
   }
 
-  @Test
-  public void testCompression() throws IOException
+  private void writeCompressedData(EvenOddHDFSExactlyOnceWriter writer, File evenFile,
+      File oddFile, List<Long> evenOffsets, List<Long> oddOffsets)
   {
-    EvenOddHDFSExactlyOnceWriter writer = new EvenOddHDFSExactlyOnceWriter();
-    writer.setFilterStreamProvider(new FilterStreamCodec.GZipFilterStreamProvider());
-
-    File evenFile = new File(testMeta.getDir(), EVEN_FILE);
-    File oddFile = new File(testMeta.getDir(), ODD_FILE);
-
-    // To get around the multi member gzip issue with openjdk
-    // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4691425
-    List<Long> evenOffsets = new ArrayList<Long>();
-    List<Long> oddOffsets = new ArrayList<Long>();
-
     writer.setFilePath(testMeta.getDir());
     writer.setAlwaysWriteToTmp(false);
     writer.setup(testMeta.testOperatorContext);
@@ -1617,9 +1615,85 @@ public class AbstractFileOutputOperatorTest
     }
 
     writer.teardown();
+  }
+
+
+  @Test
+  public void testCompression() throws IOException
+  {
+    EvenOddHDFSExactlyOnceWriter writer = new EvenOddHDFSExactlyOnceWriter();
+    writer.setFilterStreamProvider(new FilterStreamCodec.GZipFilterStreamProvider());
+
+    File evenFile = new File(testMeta.getDir(), EVEN_FILE);
+    File oddFile = new File(testMeta.getDir(), ODD_FILE);
+
+    // To get around the multi member gzip issue with openjdk
+    // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4691425
+    List<Long> evenOffsets = new ArrayList<Long>();
+    List<Long> oddOffsets = new ArrayList<Long>();
+
+    writeCompressedData(writer, evenFile, oddFile, evenOffsets, oddOffsets);
 
     checkCompressedFile(evenFile, evenOffsets, 0, 5, 1000, null, null);
     checkCompressedFile(oddFile, oddOffsets, 1, 5, 1000, null, null);
+  }
+
+  @Test
+  public void testSnappyStreamProvider() throws IOException
+  {
+    EvenOddHDFSExactlyOnceWriter writer = new EvenOddHDFSExactlyOnceWriter();
+    writer.setFilterStreamProvider(new FilterStreamCodec.SnappyFilterStreamProvider());
+
+    File evenFile = new File(testMeta.getDir(), EVEN_FILE);
+    File oddFile = new File(testMeta.getDir(), ODD_FILE);
+
+    // To get around the multi member gzip issue with openjdk
+    // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4691425
+    List<Long> evenOffsets = new ArrayList<Long>();
+    List<Long> oddOffsets = new ArrayList<Long>();
+
+    writeCompressedData(writer, evenFile, oddFile, evenOffsets, oddOffsets);
+
+    checkSnappyFile(evenFile, evenOffsets, 0, 5, 1000);
+    checkSnappyFile(oddFile, oddOffsets, 1, 5, 1000);
+  }
+
+  @Test
+  public void testSnappyCompressionSimple() throws IOException
+  {
+    File snappyFile = new File(testMeta.getDir(), "snappyTestFile.snappy");
+
+    try {
+      SnappyCodec.checkNativeCodeLoaded();
+    } catch (UnsatisfiedLinkError u) {
+      System.out.println("WARNING: Skipping Snappy compression test since native libraries were not found.");
+      return;
+    } catch (RuntimeException e) {
+      System.out.println("WARNING: Skipping Snappy compression test since native libraries were not found.");
+      return;
+    }
+
+    BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(snappyFile));
+    Configuration conf = new Configuration();
+    CompressionCodec codec = (CompressionCodec) ReflectionUtils.newInstance(SnappyCodec.class, conf);
+    FilterStreamCodec.SnappyFilterStream filterStream = new FilterStreamCodec.SnappyFilterStream(
+        codec.createOutputStream(os));
+
+    int ONE_MB = 1024 * 1024;
+
+    String testStr = "TestSnap-16bytes";
+    for (int i = 0; i < ONE_MB; i++) { // write 16 MBs
+      filterStream.write(testStr.getBytes());
+    }
+    filterStream.flush();
+    filterStream.close();
+
+    CompressionInputStream is = codec.createInputStream(new FileInputStream(snappyFile));
+
+    byte[] recovered = new byte[testStr.length()];
+    int bytesRead = is.read(recovered);
+    is.close();
+    assertEquals(testStr, new String(recovered));
   }
 
   @Test
@@ -1745,6 +1819,61 @@ public class AbstractFileOutputOperatorTest
       } else {
         if (gis != null) {
           gis.close();
+        } else if (gss != null) {
+          gss.close();
+        }
+      }
+    }
+    Assert.assertEquals("Total", totalWindows, numWindows);
+  }
+
+  private void checkSnappyFile(File file, List<Long> offsets, int startVal, int totalWindows, int totalRecords) throws IOException
+  {
+    FileInputStream fis;
+    InputStream gss = null;
+    Configuration conf = new Configuration();
+    CompressionCodec codec = (CompressionCodec) ReflectionUtils.newInstance(SnappyCodec.class, conf);
+    CompressionInputStream snappyIs = null;
+
+    BufferedReader br = null;
+
+    int numWindows = 0;
+    try {
+      fis = new FileInputStream(file);
+      gss = fis;
+
+      long startOffset = 0;
+      for (long offset : offsets) {
+        // Skip initial case in case file is not yet created
+        if (offset == 0) {
+          continue;
+        }
+        long limit = offset - startOffset;
+        LimitInputStream lis = new LimitInputStream(gss, limit);
+
+        snappyIs = codec.createInputStream(lis);
+        br = new BufferedReader(new InputStreamReader(snappyIs));
+        String eline = "" + (startVal + numWindows * 2);
+        int count = 0;
+        String line;
+        while ((line = br.readLine()) != null) {
+          Assert.assertEquals("File line", eline, line);
+          ++count;
+          if ((count % totalRecords) == 0) {
+            ++numWindows;
+            eline = "" + (startVal + numWindows * 2);
+          }
+        }
+        startOffset = offset;
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    } finally {
+      if (br != null) {
+        br.close();
+      } else {
+        if (snappyIs != null) {
+          snappyIs.close();
         } else if (gss != null) {
           gss.close();
         }


### PR DESCRIPTION
* Based on existing code to output Gzip or CipherText this patch adds support for writing data out as Hadoop-readable Snappy format
* Added unit tests which validate both the provider and the simpler SnappyStream functionality.
* This patch reuses some code from existing tests where possible.