### PR TITLE
APEXMALHAR-2492 Correct usage of empty Slice in Malhar Library

### DIFF
--- a/library/src/main/java/org/apache/apex/malhar/lib/dedup/BoundedDedupOperator.java
+++ b/library/src/main/java/org/apache/apex/malhar/lib/dedup/BoundedDedupOperator.java
@@ -156,8 +156,7 @@ public class BoundedDedupOperator extends AbstractDeduper<Object>
   protected void putManagedState(Object tuple)
   {
     Slice key = getKey(tuple);
-    ((ManagedTimeStateImpl)managedState).put(getBucketId(key), DEFAULT_CONSTANT_TIME,
-        key, new Slice(new byte[0]));
+    ((ManagedTimeStateImpl)managedState).put(getBucketId(key), DEFAULT_CONSTANT_TIME, key, new Slice(null, 0, 0));
   }
 
   protected int getBucketId(Slice key)

--- a/library/src/main/java/org/apache/apex/malhar/lib/dedup/TimeBasedDedupOperator.java
+++ b/library/src/main/java/org/apache/apex/malhar/lib/dedup/TimeBasedDedupOperator.java
@@ -186,7 +186,7 @@ public class TimeBasedDedupOperator extends AbstractDeduper<Object> implements A
   @Override
   protected void putManagedState(Object tuple)
   {
-    ((ManagedTimeUnifiedStateImpl)managedState).put(getTime(tuple), getKey(tuple), new Slice(new byte[0]));
+    ((ManagedTimeUnifiedStateImpl)managedState).put(getTime(tuple), getKey(tuple), new Slice(null, 0, 0));
   }
 
 


### PR DESCRIPTION
@vlad There is another piece of code where there is possibility of creating a wrong empty Slice. 
https://github.com/apache/apex-malhar/blob/master/library/src/test/java/org/apache/apex/malhar/lib/wal/FileSystemWALTest.java#L113
Should we change the getRandomSlice() implementation if len = 0?