### PR TITLE
APEXMALHAR-2506 Added the monitoring to Kafka Consumer threads, if on…

### DIFF
--- a/kafka/kafka-common/src/main/java/org/apache/apex/malhar/kafka/AbstractKafkaInputOperator.java
+++ b/kafka/kafka-common/src/main/java/org/apache/apex/malhar/kafka/AbstractKafkaInputOperator.java
@@ -340,6 +340,10 @@ public abstract class AbstractKafkaInputOperator implements InputOperator,
 
   protected void processConsumerError()
   {
+    if (consumerWrapper.hasAnyKafkaReaderThreadDied()) {
+      throw new RuntimeException("Kafka Consumer threads exited.");
+    }
+
     if (consumerError != null) {
       logger.error("Error in consumer, terminating");
       throw Throwables.propagate(consumerError);


### PR DESCRIPTION
…e of them dies then the Kafka operator is killed so that it can recover from the proper state.

@PramodSSImmaneni please review.