### PR TITLE
APEXMALHAR-2513 fixes for JdbcPollOperator

### DIFF
--- a/docs/operators/jdbcPollInputOperator.md
+++ b/docs/operators/jdbcPollInputOperator.md
@@ -26,10 +26,10 @@ JDBC Poller Input operator addresses the first issue with an asynchronous worker
 Assumption is that there is an ordered column using which range queries can be formed. That means database has a column or combination of columns which has unique constraint as well as every newly inserted record should have column value more than max value in that column, as we poll only appended records.
 
 ## Use cases
-1. Scan huge database tables to either copy to other database or process it using **Apache Apex**. An example application using this operator to copy database contents to HDFS is available in the [examples repository](https://github.com/DataTorrent/examples/tree/master/tutorials/jdbcIngest). Look for "PollJdbcToHDFSApp" for example of this particular operator.
+1. Ingest large database tables. An example application that copies database contents to HDFS is available [here](https://github.com/apache/apex-malhar/blob/master/examples/jdbc/src/main/java/org/apache/apex/examples/JdbcIngest/JdbcPollerApplication.java).
 
 ## How to Use?
-The tuple type in the abstract class is a generic parameter. Concrete subclasses need to choose an appropriate class (such as String or an appropriate concrete java class, having no-argument constructor so that it can be serialized using kyro). Also implement a couple of abstract methods: `getTuple(ResultSet)` to convert database rows to objects of concrete class and `emitTuple(T)` to emit the tuple.
+The tuple type in the abstract class is a generic parameter. Concrete subclasses need to choose an appropriate class (such as String or an appropriate concrete java class, having no-argument constructor so that it can be serialized using Kryo). Also implement a couple of abstract methods: `getTuple(ResultSet)` to convert database rows to objects of concrete class and `emitTuple(T)` to emit the tuple.
 
 In principle, no ports need be defined in the rare case that the operator simply writes tuples to some external sink or merely maintains aggregated statistics. But in most common scenarios, the tuples need to be sent to one or more downstream operators for additional processing such as parsing, enrichment or aggregation; in such cases, appropriate output ports are defined and the emitTuple(T) implementation dispatches tuples to the desired output ports.
 
@@ -46,7 +46,7 @@ Only static partitioning is supported for JDBC Poller Input Operator. Configure 
 
 ```xml
   <property>
-    <name>dt.operator.{OperatorName}.prop.partitionCount</name>
+    <name>apex.operator.{OperatorName}.prop.partitionCount</name>
     <value>4</value>
   </property>
 ```
@@ -62,8 +62,7 @@ Not supported.
 1. Operator location: ***malhar-library***
 2. Available since: ***3.5.0***
 3. Operator state: ***Evolving***
-4. Java Packages:
-    * Operator: ***[com.datatorrent.lib.db.jdbc.AbstractJdbcPollInputOperator](https://www.datatorrent.com/docs/apidocs/com/datatorrent/lib/db/jdbc/AbstractJdbcPollInputOperator.html)***
+4. Java Packages: ***[AbstractJdbcPollInputOperator](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.7/com/datatorrent/lib/db/jdbc/package-summary.html)***
 
 JDBC Poller is **idempotent**, **fault-tolerant** and **statically partitionable**.
 
@@ -99,27 +98,27 @@ Of these only `store` properties, `tableName`, `columnsExpression` and `key` are
 
 ```xml
 <property>
-  <name>dt.operator.{OperatorName}.prop.tableName</name>
+  <name>apex.operator.{OperatorName}.prop.tableName</name>
   <value>mytable</value>
 </property>
 <property>
-  <name>dt.operator.{OperatorName}.prop.columnsExpression</name>
+  <name>apex.operator.{OperatorName}.prop.columnsExpression</name>
   <value>column1,column2,column4</value>
 </property>
 <property>
-  <name>dt.operator.{OperatorName}.prop.key</name>
+  <name>apex.operator.{OperatorName}.prop.key</name>
   <value>keycolumn</value>
 </property>
 <property>
-  <name>dt.operator.{OperatorName}.prop.store.databaseDriver</name>
+  <name>apex.operator.{OperatorName}.prop.store.databaseDriver</name>
   <value>com.mysql.jdbc.Driver</value>
 </property>
 <property>
-  <name>dt.operator.{OperatorName}.prop.store.databaseUrl</name>
+  <name>apex.operator.{OperatorName}.prop.store.databaseUrl</name>
   <value>jdbc:mysql://localhost:3306/mydb</value>
 </property>
 <property>
-  <name>dt.operator.{OperatorName}.prop.store.connectionProps</name>
+  <name>apex.operator.{OperatorName}.prop.store.connectionProps</name>
   <value>user:myuser,password:mypassword</value>
 </property>
 ```
@@ -147,7 +146,7 @@ This operator defines following additional properties beyond those defined in th
 
 | **Property** | **Description** | **Type** | **Mandatory** | **Default Value** |
 | -------- | ----------- | ---- | ------------------ | ------------- |
-| *fieldInfos*| [FieldInfo](https://www.datatorrent.com/docs/apidocs/com/datatorrent/lib/util/FieldInfo.html) maps a store column to a POJO field name.| List | Yes | N/A |
+| *fieldInfos*| Maps columns to POJO field names.| List | Yes | N/A |
 
 #### Platform Attributes that influence operator behavior
 | **Attribute** | **Description** | **Type** | **Mandatory** |

--- a/examples/jdbc/src/main/resources/META-INF/properties-PollJdbcToHDFSApp.xml
+++ b/examples/jdbc/src/main/resources/META-INF/properties-PollJdbcToHDFSApp.xml
@@ -23,68 +23,68 @@
     <!-- Static partitioning, specify the partition count, this decides how 
         many ranges would be initiated -->
     <property>
-        <name>dt.application.operator.JdbcPoller.prop.partitionCount</name>
+        <name>apex.operator.JdbcPoller.prop.partitionCount</name>
         <value>2</value>
     </property>
 
     <property>
-        <name>dt.application.operator.JdbcPoller.prop.store.databaseDriver</name>
+        <name>apex.operator.JdbcPoller.prop.store.databaseDriver</name>
         <!-- replace value with your jbdc driver -->
         <value>org.hsqldb.jdbcDriver</value>
     </property>
 
     <property>
-        <name>dt.application.operator.JdbcPoller.prop.store.databaseUrl</name>
+        <name>apex.operator.JdbcPoller.prop.store.databaseUrl</name>
         <!-- replace value with your jbdc  url -->
         <value>jdbc:hsqldb:mem:test</value>
     </property>
 
     <!--property>
-        <name>dt.application.operator.JdbcPoller.prop.store.userName</name>
+        <name>apex.operator.JdbcPoller.prop.store.connectionProperties(user)</name>
         <value>username</value>
     </property>
     
     <property>
-        <name>dt.application.operator.JdbcPoller.prop.store.password</name>
+        <name>apex.operator.JdbcPoller.prop.store.connectionProperties(password)</name>
         <value>password</value>
     </property-->
 
     <!-- Batch size for poller -->
     <property>
-        <name>dt.application.operator.JdbcPoller.prop.batchSize</name>
+        <name>apex.operator.JdbcPoller.prop.batchSize</name>
         <value>50</value>
     </property>
 
     <!-- look-up key for forming range queries, this would be the column name 
         on which the table is sorted -->
     <property>
-        <name>dt.application.operator.JdbcPoller.prop.key</name>
+        <name>apex.operator.JdbcPoller.prop.key</name>
         <value>ACCOUNT_NO</value>
     </property>
 
     <property>
-        <name>dt.application.operator.JdbcPoller.prop.columnsExpression</name>
+        <name>apex.operator.JdbcPoller.prop.columnsExpression</name>
         <value>ACCOUNT_NO,NAME,AMOUNT</value>
     </property>
     <property>
-      <name>dt.application.operator.JdbcPoller.port.outputPort.attr.TUPLE_CLASS</name>
+      <name>apex.operator.JdbcPoller.port.outputPort.attr.TUPLE_CLASS</name>
       <value>org.apache.apex.examples.JdbcIngest.PojoEvent</value>
     </property>
 
     <!-- Table name -->
     <property>
-        <name>dt.application.operator.JdbcPoller.prop.tableName</name>
+        <name>apex.operator.JdbcPoller.prop.tableName</name>
         <value>test_event_table</value>
     </property>
 
     <property>
-        <name>dt.application.operator.JdbcPoller.prop.pollInterval</name>
+        <name>apex.operator.JdbcPoller.prop.pollInterval</name>
         <value>1000</value>
     </property>
 
     <!-- Output folder for HDFS output operator -->
     <property>
-        <name>dt.application.operator.Writer.filePath</name>
+        <name>apex.operator.Writer.filePath</name>
         <value>/tmp/test/output</value>
     </property>
 

--- a/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPollInputOperator.java
+++ b/library/src/main/java/com/datatorrent/lib/db/jdbc/JdbcPollInputOperator.java
@@ -68,8 +68,9 @@ public class JdbcPollInputOperator extends AbstractJdbcPollInputOperator<String>
   {
     StringBuilder resultTuple = new StringBuilder();
     try {
-      for (String obj : emitColumns) {
-        resultTuple.append(rs.getObject(obj) + ",");
+      int columnCount = rs.getMetaData().getColumnCount();
+      for (int i = 0; i < columnCount; i++) {
+        resultTuple.append(rs.getObject(i + 1) + ",");
       }
       return resultTuple.substring(0, resultTuple.length() - 1); //remove last comma
     } catch (SQLException e) {

--- a/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcPojoPollableOpeartorTest.java
+++ b/library/src/test/java/com/datatorrent/lib/db/jdbc/JdbcPojoPollableOpeartorTest.java
@@ -87,7 +87,7 @@ public class JdbcPojoPollableOpeartorTest extends JdbcOperatorTest
   }
 
   @Test
-  public void testDBPoller() throws InterruptedException
+  public void testDBPoller() throws Exception
   {
     insertEvents(10, true, 0);
 
@@ -179,7 +179,7 @@ public class JdbcPojoPollableOpeartorTest extends JdbcOperatorTest
   {
     int operatorId = 1;
     when(windowDataManagerMock.getLargestCompletedWindow()).thenReturn(1L);
-    when(windowDataManagerMock.retrieve(1)).thenReturn(new MutablePair<Integer, Integer>(0, 4));
+    when(windowDataManagerMock.retrieve(1)).thenReturn(new MutablePair<>(0, 4));
 
     insertEvents(10, true, 0);
 
@@ -207,7 +207,8 @@ public class JdbcPojoPollableOpeartorTest extends JdbcOperatorTest
     inputOperator.setFetchSize(100);
     inputOperator.setBatchSize(100);
     inputOperator.lastEmittedRow = 0; //setting as not calling partition logic
-    inputOperator.rangeQueryPair = new KeyValPair<Integer, Integer>(0, 8);
+    inputOperator.isPollerPartition = true;
+    inputOperator.rangeQueryPair = new KeyValPair<>(0, 8);
 
     inputOperator.outputPort.setup(tpc);
     inputOperator.setScheduledExecutorService(mockscheduler);
@@ -219,15 +220,17 @@ public class JdbcPojoPollableOpeartorTest extends JdbcOperatorTest
     inputOperator.outputPort.setSink(sink);
     inputOperator.beginWindow(0);
     verify(mockscheduler, times(0)).scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+    verify(mockscheduler, times(0)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
     inputOperator.emitTuples();
     inputOperator.endWindow();
     inputOperator.beginWindow(1);
     verify(mockscheduler, times(1)).scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+    verify(mockscheduler, times(0)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
 
   }
 
   @Test
-  public void testDBPollerExtraField() throws InterruptedException
+  public void testDBPollerExtraField() throws Exception
   {
     insertEvents(10, true, 0);
 


### PR DESCRIPTION
Fix result set extraction to use column index.
Exit static partitions after work is done.
Propagate all exceptions from poller task.
Add comment regarding SQL dialect support.
Fix poller example properties.
Documentation fixes.

@devtagare please review