### PR TITLE
APEXMALHAR-2525 Fix yahoofinance example

### DIFF
--- a/examples/yahoofinance/src/main/java/org/apache/apex/examples/yahoofinance/ApplicationWithDerbySQL.java
+++ b/examples/yahoofinance/src/main/java/org/apache/apex/examples/yahoofinance/ApplicationWithDerbySQL.java
@@ -38,7 +38,7 @@ public class ApplicationWithDerbySQL implements StreamingApplication
   @Override
   public void populateDAG(DAG dag, Configuration conf)
   {
-    String symbolStr = conf.get(ApplicationWithDerbySQL.class.getName() + ".tickerSymbols", "YHOO,GOOG,AAPL,FB,AMZN,NFLX,IBM");
+    String symbolStr = conf.get(ApplicationWithDerbySQL.class.getName() + ".tickerSymbols", "AABA,GOOG,AAPL,FB,AMZN,NFLX,IBM");
 
     String[] symbols = symbolStr.split(",");
 

--- a/examples/yahoofinance/src/main/java/org/apache/apex/examples/yahoofinance/StockTickInput.java
+++ b/examples/yahoofinance/src/main/java/org/apache/apex/examples/yahoofinance/StockTickInput.java
@@ -86,7 +86,7 @@ public class StockTickInput implements InputOperator
   public final transient DefaultOutputPort<KeyValPair<String, String>> time = new DefaultOutputPort<KeyValPair<String, String>>();
 
   /**
-   * Prepare URL from symbols and parameters. URL will be something like: http://download.finance.yahoo.com/d/quotes.csv?s=IBM,GOOG,AAPL,YHOO&f=sl1vt1
+   * Prepare URL from symbols and parameters. URL will be something like: http://download.finance.yahoo.com/d/quotes.csv?s=IBM,GOOG,AAPL,AABA&f=sl1vt1
    *
    * @return the URL
    */

--- a/examples/yahoofinance/src/main/java/org/apache/apex/examples/yahoofinance/YahooFinanceApplication.java
+++ b/examples/yahoofinance/src/main/java/org/apache/apex/examples/yahoofinance/YahooFinanceApplication.java
@@ -91,8 +91,8 @@ import com.datatorrent.lib.util.HighLow;
  * <pre>
  *  Price SMA: AAPL=435.965
  * Price SMA: GOOG=877.0
- * QUOTE: {YHOO=[26.37, 9760360, 4:00pm, null, null], IBM=[203.77, 2899698, 4:00pm, null, null], GOOG=[877.0, 2069614, 4:00pm, null, null], AAPL=[435.965, 10208099, 4:00pm, null, null]}
- * Price SMA: YHOO=26.37
+ * QUOTE: {AABA=[26.37, 9760360, 4:00pm, null, null], IBM=[203.77, 2899698, 4:00pm, null, null], GOOG=[877.0, 2069614, 4:00pm, null, null], AAPL=[435.965, 10208099, 4:00pm, null, null]}
+ * Price SMA: AABA=26.37
  * </pre>
  *
  * Scaling Options : <br>
@@ -196,7 +196,7 @@ public class YahooFinanceApplication implements StreamingApplication
   protected int streamingWindowSizeMilliSeconds = 1000; // 1 second
   protected int appWindowCountMinute = 60;   // 1 minute
   protected int appWindowCountSMA = 300;  // 5 minute
-  //protected String[] tickers = {"IBM", "GOOG", "AAPL", "YHOO"};
+  //protected String[] tickers = {"IBM", "GOOG", "AAPL", "AABA"};
 
   /**
    * Instantiate stock input operator for actual Yahoo finance ticks of symbol, last price, total daily volume, and last traded price.

--- a/examples/yahoofinance/src/main/java/org/apache/apex/examples/yahoofinance/YahooFinanceCSVInputOperator.java
+++ b/examples/yahoofinance/src/main/java/org/apache/apex/examples/yahoofinance/YahooFinanceCSVInputOperator.java
@@ -94,7 +94,7 @@ public class YahooFinanceCSVInputOperator extends SimpleSinglePortInputOperator<
 
   /**
    * Prepare URL from symbols and parameters.
-   * URL will be something like: http://download.finance.yahoo.com/d/quotes.csv?s=GOOG,FB,YHOO&f=sl1vt1&e=.csv
+   * URL will be something like: http://download.finance.yahoo.com/d/quotes.csv?s=GOOG,FB,AABA&f=sl1vt1&e=.csv
    * @return
    */
   private String prepareURL()

--- a/examples/yahoofinance/src/main/resources/META-INF/properties.xml
+++ b/examples/yahoofinance/src/main/resources/META-INF/properties.xml
@@ -34,7 +34,7 @@
   </property>
   <property>
     <name>dt.application.YahooFinanceExampleWithChart.operator.StockTickInput.tickers</name>
-    <value>IBM,GOOG,AAPL,YHOO</value>
+    <value>IBM,GOOG,AAPL,AABA</value>
   </property>
   <property>
     <name>dt.application.*.operator.*.attr.MEMORY_MB</name>
@@ -50,11 +50,11 @@
   </property>
   <property>
     <name>dt.application.YahooFinanceExample.operator.StockTickInput.tickers</name>
-    <value>IBM,GOOG,AAPL,YHOO</value>
+    <value>IBM,GOOG,AAPL,AABA</value>
   </property>
   <property>
     <name>dt.application.YahooFinanceWithoutChartExample.operator.StockTickInput.tickers</name>
-    <value>IBM,GOOG,AAPL,YHOO</value>
+    <value>IBM,GOOG,AAPL,AABA</value>
   </property>
   <property>
     <name>dt.application.YahooFinanceExampleWithChart.operator.AverageChart.yAxisLabel</name>


### PR DESCRIPTION
This fixes the yahoofinance example in the malhar-examples artifact.
The StockTickInput Operator uses stock ticker symbols to fetch stock
information from the yahoo finance api. Because the default tickers
included "YHOO", which does not exist anymore, the StockTickInput
operator would crash because it fails to parse a "N/A" response from the
api into a number.

This is fixed with this commit by changing all "YHOO" tickers to "AABA",
which is the new ticker of Altaba Inc., that Yahoo is now traded under