### PR TITLE
APEXMALHAR-2489 Change algorithm for running average

### DIFF
--- a/library/src/main/java/com/datatorrent/lib/math/RunningAverage.java
+++ b/library/src/main/java/com/datatorrent/lib/math/RunningAverage.java
@@ -64,9 +64,10 @@ public class RunningAverage extends BaseOperator
     @Override
     public void process(Number tuple)
     {
-      double sum = (RunningAverage.this.count * average) + tuple.doubleValue();
-      RunningAverage.this.count++;
-      average = sum / RunningAverage.this.count;
+      // Floating mean as explained on http://www.heikohoffmann.de/htmlthesis/node134.html
+      double firstPart = (1.0 / (++RunningAverage.this.count));
+      double secondPart = (tuple.doubleValue() - average);
+      average += (firstPart * secondPart);
     }
   };
 

--- a/library/src/test/java/com/datatorrent/lib/math/RunningAverageTest.java
+++ b/library/src/test/java/com/datatorrent/lib/math/RunningAverageTest.java
@@ -29,8 +29,17 @@ import static org.junit.Assert.assertEquals;
  */
 public class RunningAverageTest
 {
-  public RunningAverageTest()
+
+  @Test
+  public void testDoesNotOverflow()
   {
+    RunningAverage instance = new RunningAverage();
+    instance.input.process(Double.MAX_VALUE);
+    assertEquals("first average", Double.MAX_VALUE, instance.average, 0);
+
+    instance.input.process(Double.MAX_VALUE);
+
+    assertEquals("second average", Double.MAX_VALUE, instance.average, 0);
   }
 
   @Test


### PR DESCRIPTION
The current algorithm for calculating the running average was subject to
a potential overflow, because part of the formula required the
average value (average) to be multiplied with the number of processed
tuples (count). `average * count` would for example overflow when e.g.
`average > Double.MAX_VALUE` and `count >=2`

This PR changes the formula used to the one described on
http://www.heikohoffmann.de/htmlthesis/node134.html, where such a
multiplication is not necessary anymore. It also adds a unit test which
checks that there is not overflow occuring anymore