### PR TITLE
APEXMALHAR-2517 - Shaded 3.7.0 release with legacy packages

### DIFF
--- a/shaded-malhar37/pom.xml
+++ b/shaded-malhar37/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>18</version>
+    <relativePath/>
+  </parent>
+  <groupId>org.apache.apex</groupId>
+  <artifactId>apex-shaded-malhar37</artifactId>
+  <version>1.0.0</version>
+
+  <name>Apache Apex Malhar 3.7 compatibility jar</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <!-- skip source archives -->
+    <assembly.attach>false</assembly.attach>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <skipSource>true</skipSource>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+	      <createSourcesJar>true</createSourcesJar>
+	      <shadeSourcesContent>true</shadeSourcesContent>
+              <artifactSet>
+                <includes>
+                  <include>org.apache.apex:malhar-library</include>
+                  <include>org.apache.apex:malhar-contrib</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.apex.malhar.lib</pattern>
+                  <shadedPattern>shaded.malhar37.lib</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.apex.malhar.contrib</pattern>
+                  <shadedPattern>shaded.malhar37.contrib</shadedPattern>
+                </relocation>
+              </relocations>
+              <dependencyReducedPomLocation>target/reduced-pom.xml</dependencyReducedPomLocation>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <configuration>
+          <outputDirectory>${project.basedir}/target</outputDirectory>
+          <flattenMode>clean</flattenMode>
+          <pomElements><name/></pomElements>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>package</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.apex</groupId>
+      <artifactId>malhar-library</artifactId>
+      <version>3.7.0</version>
+      <type>jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.apex</groupId>
+      <artifactId>malhar-contrib</artifactId>
+      <version>3.7.0</version>
+      <type>jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
The resulting artifact will contain the old com.datatorrent packages as of release 3.7 and will become a dependency of malhar-library with the upcoming release to provide these classes for backward compatibility (classes removed in #662).

To be merged after #662  
